### PR TITLE
Add generic ValueType to RACSignal and RACCommand

### DIFF
--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -774,13 +774,6 @@
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		A97451361B3A935E00F48E55 /* watchOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		A9B315541B3940610001CB9C /* ReactiveObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BE330A0E1D634F1E00806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = build/Debug/ReactiveSwift.framework; sourceTree = "<group>"; };
-		BE330A101D634F2900806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = build/Debug/ReactiveSwift.framework; sourceTree = "<group>"; };
-		BE330A121D634F2E00806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-iphoneos/ReactiveSwift.framework"; sourceTree = "<group>"; };
-		BE330A141D634F4000806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-iphoneos/ReactiveSwift.framework"; sourceTree = "<group>"; };
-		BE330A161D634F4E00806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-watchos/ReactiveSwift.framework"; sourceTree = "<group>"; };
-		BE330A181D634F5900806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-appletvos/ReactiveSwift.framework"; sourceTree = "<group>"; };
-		BE330A1A1D634F5F00806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-appletvos/ReactiveSwift.framework"; sourceTree = "<group>"; };
 		D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		D037642C19EDA41200A782A9 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
@@ -1145,20 +1138,6 @@
 			path = watchOS;
 			sourceTree = "<group>";
 		};
-		BE330A0D1D634F1E00806963 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BE330A1A1D634F5F00806963 /* ReactiveSwift.framework */,
-				BE330A181D634F5900806963 /* ReactiveSwift.framework */,
-				BE330A161D634F4E00806963 /* ReactiveSwift.framework */,
-				BE330A141D634F4000806963 /* ReactiveSwift.framework */,
-				BE330A121D634F2E00806963 /* ReactiveSwift.framework */,
-				BE330A101D634F2900806963 /* ReactiveSwift.framework */,
-				BE330A0E1D634F1E00806963 /* ReactiveSwift.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		D037666519EDA57100A782A9 /* extobjc */ = {
 			isa = PBXGroup;
 			children = (
@@ -1178,7 +1157,6 @@
 				D04725F919E49ED7006002AA /* ReactiveObjCTests */,
 				D047262519E49FE8006002AA /* Configuration */,
 				D04725EB19E49ED7006002AA /* Products */,
-				BE330A0D1D634F1E00806963 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 			usesTabs = 1;

--- a/ReactiveObjC/MKAnnotationView+RACSignalSupport.h
+++ b/ReactiveObjC/MKAnnotationView+RACSignalSupport.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import <MapKit/MapKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
+@class RACUnit;
 
 @interface MKAnnotationView (RACSignalSupport)
 
@@ -24,6 +25,6 @@
 ///     subscribeNext:^(UIButton *x) {
 ///         // do other things
 ///     }];
-@property (nonatomic, strong, readonly) RACSignal *rac_prepareForReuseSignal;
+@property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end

--- a/ReactiveObjC/NSControl+RACCommandSupport.h
+++ b/ReactiveObjC/NSControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class RACCommand<__contravariant InputType>;
+@class RACCommand<__contravariant InputType, __covariant ValueType>;
 
 @interface NSControl (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand<__kindof NSControl *> *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof NSControl *, id> *rac_command;
 
 @end

--- a/ReactiveObjC/NSControl+RACTextSignalSupport.h
+++ b/ReactiveObjC/NSControl+RACTextSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSControl (RACTextSignalSupport)
 
@@ -19,6 +19,6 @@
 ///
 /// Returns a signal which sends the current string value of the receiver, then
 /// the new value any time it changes.
-- (RACSignal *)rac_textSignal;
+- (RACSignal<NSString *> *)rac_textSignal;
 
 @end

--- a/ReactiveObjC/NSData+RACSupport.h
+++ b/ReactiveObjC/NSData+RACSupport.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACScheduler;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSData (RACSupport)
 
@@ -17,6 +17,6 @@
 // Sends the data or the error.
 //
 // scheduler - cannot be nil.
-+ (RACSignal *)rac_readContentsOfURL:(NSURL *)URL options:(NSDataReadingOptions)options scheduler:(RACScheduler *)scheduler;
++ (RACSignal<NSData *> *)rac_readContentsOfURL:(NSURL *)URL options:(NSDataReadingOptions)options scheduler:(RACScheduler *)scheduler;
 
 @end

--- a/ReactiveObjC/NSFileHandle+RACSupport.h
+++ b/ReactiveObjC/NSFileHandle+RACSupport.h
@@ -8,12 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSFileHandle (RACSupport)
 
 // Read any available data in the background and send it. Completes when data
 // length is <= 0.
-- (RACSignal *)rac_readInBackground;
+- (RACSignal<NSData *> *)rac_readInBackground;
 
 @end

--- a/ReactiveObjC/NSNotificationCenter+RACSupport.h
+++ b/ReactiveObjC/NSNotificationCenter+RACSupport.h
@@ -8,11 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSNotificationCenter (RACSupport)
 
 // Sends the NSNotification every time the notification is posted.
-- (RACSignal *)rac_addObserverForName:(NSString *)notificationName object:(id)object;
+- (RACSignal<NSNotification *> *)rac_addObserverForName:(NSString *)notificationName object:(id)object;
 
 @end

--- a/ReactiveObjC/NSObject+RACDeallocating.h
+++ b/ReactiveObjC/NSObject+RACDeallocating.h
@@ -10,7 +10,7 @@
 
 @class RACCompoundDisposable;
 @class RACDisposable;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSObject (RACDeallocating)
 

--- a/ReactiveObjC/NSObject+RACLifting.h
+++ b/ReactiveObjC/NSObject+RACLifting.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSObject (RACLifting)
 

--- a/ReactiveObjC/NSObject+RACPropertySubscribing.h
+++ b/ReactiveObjC/NSObject+RACPropertySubscribing.h
@@ -65,7 +65,7 @@
 #endif
 
 @class RACDisposable;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSObject (RACPropertySubscribing)
 

--- a/ReactiveObjC/NSObject+RACSelectorSignal.h
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 /// The domain for any errors originating from -rac_signalForSelector:.
 extern NSString * const RACSelectorSignalErrorDomain;

--- a/ReactiveObjC/NSString+RACSupport.h
+++ b/ReactiveObjC/NSString+RACSupport.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACScheduler;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSString (RACSupport)
 
@@ -17,6 +17,6 @@
 // Note that encoding won't be valid until the signal completes successfully.
 //
 // scheduler - cannot be nil.
-+ (RACSignal *)rac_readContentsOfURL:(NSURL *)URL usedEncoding:(NSStringEncoding *)encoding scheduler:(RACScheduler *)scheduler;
++ (RACSignal<NSString *> *)rac_readContentsOfURL:(NSURL *)URL usedEncoding:(NSStringEncoding *)encoding scheduler:(RACScheduler *)scheduler;
 
 @end

--- a/ReactiveObjC/NSText+RACSignalSupport.h
+++ b/ReactiveObjC/NSText+RACSignalSupport.h
@@ -8,12 +8,12 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSText (RACSignalSupport)
 
 /// Returns a signal which sends the current `string` of the receiver, then the
 /// new value any time it changes.
-- (RACSignal *)rac_textSignal;
+- (RACSignal<NSString *> *)rac_textSignal;
 
 @end

--- a/ReactiveObjC/NSURLConnection+RACSupport.h
+++ b/ReactiveObjC/NSURLConnection+RACSupport.h
@@ -8,7 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACTuple;
+@class RACSignal<__covariant ValueType>;
 
 @interface NSURLConnection (RACSupport)
 
@@ -20,6 +21,6 @@
 // then send a `RACTuple` of the received `NSURLResponse` and downloaded
 // `NSData`, and complete on a background thread. If any errors occur, the
 // returned signal will error out.
-+ (RACSignal *)rac_sendAsynchronousRequest:(NSURLRequest *)request;
++ (RACSignal<RACTuple *> *)rac_sendAsynchronousRequest:(NSURLRequest *)request;
 
 @end

--- a/ReactiveObjC/RACCommand.h
+++ b/ReactiveObjC/RACCommand.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 NS_ASSUME_NONNULL_BEGIN
 
 /// The domain for errors originating within `RACCommand`.
@@ -25,7 +25,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 
 /// A command is a signal triggered in response to some action, typically
 /// UI-related.
-@interface RACCommand<__contravariant InputType> : NSObject
+@interface RACCommand<__contravariant InputType, __covariant ValueType> : NSObject
 
 /// A signal of the signals returned by successful invocations of -execute:
 /// (i.e., while the receiver is `enabled`).
@@ -36,7 +36,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 /// 
 /// Only executions that begin _after_ subscription will be sent upon this
 /// signal. All inner signals will arrive upon the main thread.
-@property (nonatomic, strong, readonly) RACSignal *executionSignals;
+@property (nonatomic, strong, readonly) RACSignal<RACSignal<ValueType> *> *executionSignals;
 
 /// A signal of whether this command is currently executing.
 ///
@@ -46,7 +46,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///
 /// This signal will send its current value upon subscription, and then all
 /// future values on the main thread.
-@property (nonatomic, strong, readonly) RACSignal *executing;
+@property (nonatomic, strong, readonly) RACSignal<NSNumber *> *executing;
 
 /// A signal of whether this command is able to execute.
 ///
@@ -60,7 +60,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///
 /// This signal will send its current value upon subscription, and then all
 /// future values on the main thread.
-@property (nonatomic, strong, readonly) RACSignal *enabled;
+@property (nonatomic, strong, readonly) RACSignal<NSNumber *> *enabled;
 
 /// Forwards any errors that occur within signals returned by -execute:.
 ///
@@ -70,7 +70,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///
 /// After subscription, this signal will send all future errors on the main
 /// thread.
-@property (nonatomic, strong, readonly) RACSignal *errors;
+@property (nonatomic, strong, readonly) RACSignal<NSError *> *errors;
 
 /// Whether the command allows multiple executions to proceed concurrently.
 ///
@@ -93,7 +93,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///                 to a replay subject, sent on `executionSignals`, then
 ///                 subscribed to synchronously. Neither the block nor the
 ///                 returned signal may be nil.
-- (id)initWithEnabled:(nullable RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
+- (id)initWithEnabled:(nullable RACSignal<NSNumber *> *)enabledSignal signalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
 
 /// If the receiver is enabled, this method will:
 ///
@@ -108,7 +108,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 /// Returns the multicasted signal, after subscription. If the receiver is not
 /// enabled, returns a signal that will send an error with code
 /// RACCommandErrorNotEnabled.
-- (RACSignal *)execute:(nullable InputType)input;
+- (RACSignal<ValueType> *)execute:(nullable InputType)input;
 
 NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveObjC/RACDelegateProxy.h
+++ b/ReactiveObjC/RACDelegateProxy.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 // A private delegate object suitable for using
 // -rac_signalForSelector:fromProtocol: upon.

--- a/ReactiveObjC/RACMulticastConnection.h
+++ b/ReactiveObjC/RACMulticastConnection.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACDisposable;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 /// A multicast connection encapsulates the idea of sharing one subscription to a
 /// signal to many subscribers. This is most often needed if the subscription to

--- a/ReactiveObjC/RACPassthroughSubscriber.h
+++ b/ReactiveObjC/RACPassthroughSubscriber.h
@@ -10,7 +10,7 @@
 #import "RACSubscriber.h"
 
 @class RACCompoundDisposable;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 // A private subscriber that passes through all events to another subscriber
 // while not disposed.

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -10,7 +10,7 @@
 #import "RACStream.h"
 
 @class RACScheduler;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 /// Represents an immutable sequence of values. Unless otherwise specified, the
 /// sequences' values are evaluated lazily on demand. Like Cocoa collections,

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -14,7 +14,7 @@
 @class RACSubject;
 @protocol RACSubscriber;
 
-@interface RACSignal : RACStream
+@interface RACSignal<__covariant ValueType> : RACStream
 NS_ASSUME_NONNULL_BEGIN
 
 /// Creates a new signal. This is the preferred way to create a new signal
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface RACSignal (Subscription)
+@interface RACSignal<__covariant ValueType> (Subscription)
 
 /// Subscribes `subscriber` to changes on the receiver. The receiver defines which
 /// events it actually sends and in what situations the events are sent.
@@ -134,13 +134,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Convenience method to subscribe to the `next` event.
 ///
 /// This corresponds to `IObserver<T>.OnNext` in Rx.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock;
+- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock;
 
 /// Convenience method to subscribe to the `next` and `completed` events.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to the `next`, `completed`, and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `error` events.
 ///
@@ -153,7 +153,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `next` and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock;
+- (RACDisposable *)subscribeNext:(void (^)(ValueType _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock;
 
 /// Convenience method to subscribe to `error` and `completed` events.
 - (RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Additional methods to assist with unit testing.
 ///
 /// **These methods should never ship in production code.**
-@interface RACSignal (Testing)
+@interface RACSignal<__covariant ValueType> (Testing)
 
 /// Spins the main run loop for a short while, waiting for the receiver to send a `next`.
 ///
@@ -196,7 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns the first value received, or `defaultValue` if no value is received
 /// before the signal finishes or the method times out.
-- (nullable id)asynchronousFirstOrDefault:(nullable id)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
+- (nullable ValueType)asynchronousFirstOrDefault:(nullable ValueType)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
 
 /// Spins the main run loop for a short while, waiting for the receiver to complete.
 ///

--- a/ReactiveObjC/RACSignalSequence.h
+++ b/ReactiveObjC/RACSignalSequence.h
@@ -8,7 +8,7 @@
 
 #import "RACSequence.h"
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 // Private class that adapts a RACSignal to the RACSequence interface.
 @interface RACSignalSequence : RACSequence

--- a/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <ReactiveObjC/EXTKeyPathCoding.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 /// Assigns a signal to an object property, automatically setting the given key
 /// path on every `next`. When the signal completes, the binding is automatically

--- a/ReactiveObjC/UIActionSheet+RACSignalSupport.h
+++ b/ReactiveObjC/UIActionSheet+RACSignalSupport.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @class RACDelegateProxy;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UIActionSheet (RACSignalSupport)
 
@@ -27,6 +27,6 @@
 ///
 /// Returns a signal which will send the index of the specific button clicked.
 /// The signal will complete when the receiver is deallocated.
-- (RACSignal *)rac_buttonClickedSignal;
+- (RACSignal<NSNumber *> *)rac_buttonClickedSignal;
 
 @end

--- a/ReactiveObjC/UIAlertView+RACSignalSupport.h
+++ b/ReactiveObjC/UIAlertView+RACSignalSupport.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @class RACDelegateProxy;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UIAlertView (RACSignalSupport)
 
@@ -30,7 +30,7 @@
 ///
 /// Returns a signal which will send the index of the specific button clicked.
 /// The signal will complete itself when the receiver is deallocated.
-- (RACSignal *)rac_buttonClickedSignal;
+- (RACSignal<NSNumber *> *)rac_buttonClickedSignal;
 
 /// Creates a signal for dismissal of the receiver.
 ///
@@ -42,6 +42,6 @@
 ///
 /// Returns a signal which will send the index of the button associated with the
 /// dismissal. The signal will complete itself when the receiver is deallocated.
-- (RACSignal *)rac_willDismissSignal;
+- (RACSignal<NSNumber *> *)rac_willDismissSignal;
 
 @end

--- a/ReactiveObjC/UIBarButtonItem+RACCommandSupport.h
+++ b/ReactiveObjC/UIBarButtonItem+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand<__contravariant InputType>;
+@class RACCommand<__contravariant InputType, __covariant ValueType>;
 
 @interface UIBarButtonItem (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand<__kindof UIBarButtonItem *> *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIBarButtonItem *, id> *rac_command;
 
 @end

--- a/ReactiveObjC/UIButton+RACCommandSupport.h
+++ b/ReactiveObjC/UIButton+RACCommandSupport.h
@@ -8,13 +8,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand<__contravariant InputType>;
+@class RACCommand<__contravariant InputType, __covariant ValueType>;
 
 @interface UIButton (RACCommandSupport)
 
 /// Sets the button's command. When the button is clicked, the command is
 /// executed with the sender of the event. The button's enabledness is bound
 /// to the command's `canExecute`.
-@property (nonatomic, strong) RACCommand<__kindof UIButton *> *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIButton *, id> *rac_command;
 
 @end

--- a/ReactiveObjC/UICollectionReusableView+RACSignalSupport.h
+++ b/ReactiveObjC/UICollectionReusableView+RACSignalSupport.h
@@ -8,7 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
+@class RACUnit;
 
 // This category is only applicable to iOS >= 6.0.
 @interface UICollectionReusableView (RACSignalSupport)
@@ -24,6 +25,6 @@
 ///     subscribeNext:^(UIButton *x) {
 ///         // do other things
 ///     }];
-@property (nonatomic, strong, readonly) RACSignal *rac_prepareForReuseSignal;
+@property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end

--- a/ReactiveObjC/UIControl+RACSignalSupport.h
+++ b/ReactiveObjC/UIControl+RACSignalSupport.h
@@ -8,12 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UIControl (RACSignalSupport)
 
 /// Creates and returns a signal that sends the sender of the control event
 /// whenever one of the control events is triggered.
-- (RACSignal *)rac_signalForControlEvents:(UIControlEvents)controlEvents;
+- (RACSignal<__kindof UIControl *> *)rac_signalForControlEvents:(UIControlEvents)controlEvents;
 
 @end

--- a/ReactiveObjC/UIGestureRecognizer+RACSignalSupport.h
+++ b/ReactiveObjC/UIGestureRecognizer+RACSignalSupport.h
@@ -8,11 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UIGestureRecognizer (RACSignalSupport)
 
 /// Returns a signal that sends the receiver when its gesture occurs.
-- (RACSignal *)rac_gestureSignal;
+- (RACSignal<__kindof UIGestureRecognizer *> *)rac_gestureSignal;
 
 @end

--- a/ReactiveObjC/UIImagePickerController+RACSignalSupport.h
+++ b/ReactiveObjC/UIImagePickerController+RACSignalSupport.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @class RACDelegateProxy;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UIImagePickerController (RACSignalSupport)
 
@@ -28,6 +28,6 @@
 /// Returns a signal which will send the dictionary with info for the selected image.
 /// Caller is responsible for picker controller dismissal. The signal will complete
 /// itself when the receiver is deallocated or when user cancels selection.
-- (RACSignal *)rac_imageSelectedSignal;
+- (RACSignal<NSDictionary *> *)rac_imageSelectedSignal;
 
 @end

--- a/ReactiveObjC/UIRefreshControl+RACCommandSupport.h
+++ b/ReactiveObjC/UIRefreshControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand<__contravariant InputType>;
+@class RACCommand<__contravariant InputType, __covariant ValueType>;
 
 @interface UIRefreshControl (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// When this refresh control is activated by the user, the command will be
 /// executed. Upon completion or error of the execution signal, -endRefreshing
 /// will be invoked.
-@property (nonatomic, strong) RACCommand<__kindof UIRefreshControl *> *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIRefreshControl *, id> *rac_command;
 
 @end

--- a/ReactiveObjC/UITableViewCell+RACSignalSupport.h
+++ b/ReactiveObjC/UITableViewCell+RACSignalSupport.h
@@ -8,7 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
+@class RACUnit;
 
 @interface UITableViewCell (RACSignalSupport)
 
@@ -23,6 +24,6 @@
 ///     subscribeNext:^(UIButton *x) {
 ///         // do other things
 ///     }];
-@property (nonatomic, strong, readonly) RACSignal *rac_prepareForReuseSignal;
+@property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end

--- a/ReactiveObjC/UITableViewHeaderFooterView+RACSignalSupport.h
+++ b/ReactiveObjC/UITableViewHeaderFooterView+RACSignalSupport.h
@@ -8,7 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
+@class RACUnit;
 
 // This category is only applicable to iOS >= 6.0.
 @interface UITableViewHeaderFooterView (RACSignalSupport)
@@ -24,6 +25,6 @@
 ///     subscribeNext:^(UIButton *x) {
 ///         // do other things
 ///     }];
-@property (nonatomic, strong, readonly) RACSignal *rac_prepareForReuseSignal;
+@property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end

--- a/ReactiveObjC/UITextField+RACSignalSupport.h
+++ b/ReactiveObjC/UITextField+RACSignalSupport.h
@@ -9,14 +9,14 @@
 #import <UIKit/UIKit.h>
 
 @class RACChannelTerminal;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UITextField (RACSignalSupport)
 
 /// Creates and returns a signal for the text of the field. It always starts with
 /// the current text. The signal sends next when the UIControlEventAllEditingEvents
 /// control event is fired on the control.
-- (RACSignal *)rac_textSignal;
+- (RACSignal<NSString *> *)rac_textSignal;
 
 /// Creates a new RACChannel-based binding to the receiver.
 ///

--- a/ReactiveObjC/UITextView+RACSignalSupport.h
+++ b/ReactiveObjC/UITextView+RACSignalSupport.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @class RACDelegateProxy;
-@class RACSignal;
+@class RACSignal<__covariant ValueType>;
 
 @interface UITextView (RACSignalSupport)
 
@@ -28,7 +28,7 @@
 /// Returns a signal which will send the current text upon subscription, then
 /// again whenever the receiver's text is changed. The signal will complete when
 /// the receiver is deallocated.
-- (RACSignal *)rac_textSignal;
+- (RACSignal<NSString *> *)rac_textSignal;
 
 @end
 

--- a/ReactiveObjCTests/RACCommandSpec.m
+++ b/ReactiveObjCTests/RACCommandSpec.m
@@ -199,7 +199,7 @@ qck_it(@"should invoke the signalBlock once per execution", ^{
 });
 
 qck_it(@"should send on executionSignals in order of execution", ^{
-	RACCommand<RACSequence *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSequence *seq) {
+	RACCommand<RACSequence *, NSString *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSequence *seq) {
 		return [seq signalWithScheduler:RACScheduler.immediateScheduler];
 	}];
 
@@ -221,7 +221,7 @@ qck_it(@"should send on executionSignals in order of execution", ^{
 });
 
 qck_it(@"should wait for all signals to complete or error before executing sends NO", ^{
-	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 
@@ -336,7 +336,7 @@ qck_it(@"should deliver errors from -execute:", ^{
 });
 
 qck_it(@"should deliver errors onto 'errors'", ^{
-	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 
@@ -394,7 +394,7 @@ qck_it(@"should not deliver non-error events onto 'errors'", ^{
 });
 
 qck_it(@"should send errors on the main thread", ^{
-	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 


### PR DESCRIPTION
See #12

I've made sure that this generic type can be bridged to `SignalProducer`/`Signal` by adding a new free function to https://github.com/ReactiveCocoa/ReactiveObjCBridge/ as a test.

I can start a pull request there as well (if desired) that integrates this pull request.
