### PR TITLE
Add nullability annotations to RACSubscriber

### DIFF
--- a/ReactiveObjC/RACSubscriber.h
+++ b/ReactiveObjC/RACSubscriber.h
@@ -10,6 +10,8 @@
 
 @class RACCompoundDisposable;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents any object which can directly receive values from a RACSignal.
 ///
 /// You generally shouldn't need to implement this protocol. +[RACSignal
@@ -25,7 +27,7 @@
 /// Sends the next value to subscribers.
 ///
 /// value - The value to send. This can be `nil`.
-- (void)sendNext:(id)value;
+- (void)sendNext:(nullable id)value;
 
 /// Sends the error to subscribers.
 ///
@@ -33,7 +35,7 @@
 ///
 /// This terminates the subscription, and invalidates the subscriber (such that
 /// it cannot subscribe to anything else in the future).
-- (void)sendError:(NSError *)error;
+- (void)sendError:(nullable NSError *)error;
 
 /// Sends completed to subscribers.
 ///
@@ -49,3 +51,5 @@
 - (void)didSubscribeWithDisposable:(RACCompoundDisposable *)disposable;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
In general, it seems helpful to have nullability annotations specified within `RACSubscriber.h`, though perhaps there's a strong reason for which this file hasn't already been annotated that I'm not aware of.

However, according to [SE-0140](https://github.com/apple/swift-evolution/blob/master/proposals/0140-bridge-optional-to-nsnull.md):

> when an Optional is intentionally passed into Objective-C as a nonnull object, we should bridge some value by bridging the wrapped value, and bridge nones to a singleton such as NSNull

With SE-0140, which has already been implemented in Swift 3.0.1 (available in the Xcode 8.1 beta 3), it is important that nullability annotations be specified on `RACSubscriber`. Otherwise, when `RACSubscriber.sendNext()` is passed an `Optional.none` from within Swift, Swift will (post Swift 3.0.1) be bridge this to `NSNull`, when previously (pre-Swift 3.0.1) it was visible within the Objective-C `sendNext:` implementation simply as `nil`. **This results in a change in behavior when ReactiveObjC is compiled with the Swift 3.0.1 compiler**

@raylillywhite and I observed this change in behavior in Xcode 8.1 beta 3, and have verified that adding nullability annotations restores the previous behavior that users of ReactiveObjC are relying on.

Here's the difference in the Swift generated interface before and after this change:
#### Previous Swift generated interface (from Xcode 8.1 beta 3 with Swift 3.0.1)

```
public protocol RACSubscriber : NSObjectProtocol {

    public func sendNext(_ value: Any!)

    public func sendError(_ error: Error!)

    public func sendCompleted()

    public func didSubscribe(with disposable: RACCompoundDisposable!)
}
```
#### New Swift generated interface (from Xcode 8.1 beta 3 with Swift 3.0.1):

```
public protocol RACSubscriber : NSObjectProtocol {

    public func sendNext(_ value: Any?)

    public func sendError(_ error: Error)

    public func sendCompleted()

    public func didSubscribe(with disposable: RACCompoundDisposable)
}
```

Relatedly, there seems to be a bug or limitation in the Swift compiler that causes `ReactiveObjCBridging`'s `RACSignal.toRACSignal()` function to bridge `Optional.none` to `NSNull` (in next events' values) even after added the nullability annotation to `-[RACSubscriber sendNext:]`. @raylillywhite and I are in the process of investigating this and have created ReactiveCocoa/ReactiveObjCBridge/pull/5 to address this.
