### PR TITLE
Fix linking error conflict with Mantle.

### DIFF
--- a/ReactiveObjC.podspec
+++ b/ReactiveObjC.podspec
@@ -59,4 +59,15 @@ Pod::Spec.new do |s|
 
   s.frameworks   = "Foundation"
 
+  s.prepare_command = <<-'CMD'.strip_heredoc
+                        find -E . -type f -not -name 'RAC*' -regex '.*(EXT.*|metamacros)\.[hm]$' \
+                                  -execdir mv '{}' RAC'{}' \;
+                        find . -regex '.*\.[hm]' \
+                               -exec perl -pi \
+                                          -e 's@"(?:(?!RAC)(EXT.*|metamacros))\.h"@"RAC\1.h"@' '{}' \;
+                        find . -regex '.*\.[hm]' \
+                               -exec perl -pi \
+                                          -e 's@<ReactiveObjC/(?:(?!RAC)(EXT.*))\.h>@<ReactiveObjC/RAC\1.h>@' '{}' \;
+                      CMD
+
 end


### PR DESCRIPTION
Please, review & merge to master.

In this PR fix for CocoaPods compatibility with Mantle,
which also use `metamacros`.
