### PR TITLE
Adds the compatibility with libraries such as Aspects, jsPatch or wax…

### DIFF
--- a/ReactiveObjC/NSObject+RACSelectorSignal.m
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.m
@@ -57,13 +57,6 @@ static BOOL RACForwardInvocation(id self, NSInvocation *invocation) {
 
 static void RACSwizzleForwardInvocation(Class class) {
 	SEL forwardInvocationSEL = @selector(forwardInvocation:);
-	Method forwardInvocationMethod = class_getInstanceMethod(class, forwardInvocationSEL);
-
-	// Preserve any existing implementation of -forwardInvocation:.
-	void (*originalForwardInvocation)(id, SEL, NSInvocation *) = NULL;
-	if (forwardInvocationMethod != NULL) {
-		originalForwardInvocation = (__typeof__(originalForwardInvocation))method_getImplementation(forwardInvocationMethod);
-	}
 
 	// Set up a new version of -forwardInvocation:.
 	//
@@ -77,6 +70,20 @@ static void RACSwizzleForwardInvocation(Class class) {
 	id newForwardInvocation = ^(id self, NSInvocation *invocation) {
 		BOOL matched = RACForwardInvocation(self, invocation);
 		if (matched) return;
+
+		// Fetch newest implementation of -forwardInvocation:.
+		//
+		// Implementation we preserved may be replaced in later.
+		// Continue to use old implementation will lead to an unexpected situration.
+		//
+		// This process adds the compatibility with libraries such as Aspects,
+		// jsPatch or waxPatch whom hook functions with forwardInvocation:.
+		Class originalClass = [self class];
+		Method forwardInvocationMethod = class_getInstanceMethod(originalClass, forwardInvocationSEL);
+		void (*originalForwardInvocation)(id, SEL, NSInvocation *) = NULL;
+		if (forwardInvocationMethod != NULL) {
+			originalForwardInvocation = (__typeof__(originalForwardInvocation))method_getImplementation(forwardInvocationMethod);
+		}
 
 		if (originalForwardInvocation == NULL) {
 			[self doesNotRecognizeSelector:invocation.selector];


### PR DESCRIPTION
…Patch whom hook functions with forwardInvocation:.

[Forwarded PR](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3280)

In common case, it's efficiently if we preserving the implementation of forwardInvocation: in rac_signalForSelector: and using it later.

But the preserved IMP should be updated if it has been replaced after calling rac_signalForSelector:.

Holding and invoke the old implementation may leads to an unexpected situation if an function added with jsPatch or waxPatch. (infinite loops, or crashes)

Library such as Aspects, jsPatch or waxPatch will swizzle forwardInvocation: at any time during the app running, probably.

P.S. This is an issue reported at [jsPatch's issue list](https://github.com/bang590/JSPatch/issues/292)
And I decided to make this PR to RAC after reviewed all related codes between RAC and jsPatch.

