### PR TITLE
Add nullability annotations to public headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ matrix:
         - JOB=CARTHAGE-watchOS
     - script:
       - gem install cocoapods --pre
-      - pod repo update
+      - pod --version
+      - pod repo update --silent
       - pod lib lint ReactiveObjC.podspec
       env:
         - JOB=PODSPEC

--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -2756,6 +2756,10 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wnullability-completeness",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -2775,6 +2779,10 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wnullability-completeness",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -2905,6 +2913,10 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wnullability-completeness",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Profile;
@@ -2979,6 +2991,10 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wnullability-completeness",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Test;

--- a/ReactiveObjC/MKAnnotationView+RACSignalSupport.h
+++ b/ReactiveObjC/MKAnnotationView+RACSignalSupport.h
@@ -12,6 +12,8 @@
 @class RACSignal<__covariant ValueType>;
 @class RACUnit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MKAnnotationView (RACSignalSupport)
 
 /// A signal which will send a RACUnit whenever -prepareForReuse is invoked upon
@@ -28,3 +30,5 @@
 @property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSArray+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSArray+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSArray (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
@@ -18,3 +20,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSControl+RACCommandSupport.h
+++ b/ReactiveObjC/NSControl+RACCommandSupport.h
@@ -10,6 +10,8 @@
 
 @class RACCommand<__contravariant InputType, __covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSControl (RACCommandSupport)
 
 /// Sets the control's command. When the control is clicked, the command is
@@ -17,6 +19,8 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand<__kindof NSControl *, id> *rac_command;
+@property (nonatomic, strong, nullable) RACCommand<__kindof NSControl *, id> *rac_command;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSControl+RACTextSignalSupport.h
+++ b/ReactiveObjC/NSControl+RACTextSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSControl (RACTextSignalSupport)
 
 /// Observes a text-based control for changes.
@@ -22,3 +24,5 @@
 - (RACSignal<NSString *> *)rac_textSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSData+RACSupport.h
+++ b/ReactiveObjC/NSData+RACSupport.h
@@ -11,12 +11,16 @@
 @class RACScheduler;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSData (RACSupport)
 
 // Read the data at the URL using -[NSData initWithContentsOfURL:options:error:].
 // Sends the data or the error.
 //
 // scheduler - cannot be nil.
-+ (RACSignal<NSData *> *)rac_readContentsOfURL:(NSURL *)URL options:(NSDataReadingOptions)options scheduler:(RACScheduler *)scheduler;
++ (RACSignal<NSData *> *)rac_readContentsOfURL:(nullable NSURL *)URL options:(NSDataReadingOptions)options scheduler:(RACScheduler *)scheduler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSDictionary (RACSequenceAdditions)
 
 /// Creates and returns a sequence of RACTuple key/value pairs. The key will be
@@ -29,3 +31,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_valueSequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSEnumerator+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSEnumerator+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSEnumerator (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
@@ -18,3 +20,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSFileHandle+RACSupport.h
+++ b/ReactiveObjC/NSFileHandle+RACSupport.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSFileHandle (RACSupport)
 
 // Read any available data in the background and send it. Completes when data
@@ -17,3 +19,5 @@
 - (RACSignal<NSData *> *)rac_readInBackground;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSIndexSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSIndexSet+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSIndexSet (RACSequenceAdditions)
 
 /// Creates and returns a sequence of indexes (as `NSNumber`s) corresponding to
@@ -19,3 +21,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSNotificationCenter+RACSupport.h
+++ b/ReactiveObjC/NSNotificationCenter+RACSupport.h
@@ -10,9 +10,13 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSNotificationCenter (RACSupport)
 
 // Sends the NSNotification every time the notification is posted.
-- (RACSignal<NSNotification *> *)rac_addObserverForName:(NSString *)notificationName object:(id)object;
+- (RACSignal<NSNotification *> *)rac_addObserverForName:(nullable NSString *)notificationName object:(nullable id)object;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSObject+RACAppKitBindings.h
+++ b/ReactiveObjC/NSObject+RACAppKitBindings.h
@@ -33,12 +33,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface NSObject (RACUnavailableAppKitBindings)
-
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath nilValue:(id)nilValue __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath transform:(id (^)(id value))transformBlock __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withNegatedKeyPath:(NSString *)keyPath __attribute__((unavailable("Use -rac_bind:options: instead")));
-
-@end

--- a/ReactiveObjC/NSObject+RACAppKitBindings.h
+++ b/ReactiveObjC/NSObject+RACAppKitBindings.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (RACAppKitBindings)
 
 /// Invokes -rac_channelToBinding:options: without any options.
@@ -26,9 +28,11 @@
 ///
 /// Returns a RACChannelTerminal which will send future values from the receiver,
 /// and update the receiver when values are sent to the terminal.
-- (RACChannelTerminal *)rac_channelToBinding:(NSString *)binding options:(NSDictionary *)options;
+- (RACChannelTerminal *)rac_channelToBinding:(NSString *)binding options:(nullable NSDictionary *)options;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface NSObject (RACUnavailableAppKitBindings)
 

--- a/ReactiveObjC/NSObject+RACAppKitBindings.m
+++ b/ReactiveObjC/NSObject+RACAppKitBindings.m
@@ -86,7 +86,6 @@
 	NSCParameterAssert(bindingName != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_target = target;
 	_bindingName = [bindingName copy];

--- a/ReactiveObjC/NSObject+RACDeallocating.h
+++ b/ReactiveObjC/NSObject+RACDeallocating.h
@@ -28,10 +28,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface NSObject (RACUnavailableDeallocating)
-
-- (RACSignal *)rac_didDeallocSignal __attribute__((unavailable("Use -rac_willDeallocSignal")));
-- (void)rac_addDeallocDisposable:(RACDisposable *)disposable __attribute__((unavailable("Add disposables to -rac_deallocDisposable instead")));
-
-@end

--- a/ReactiveObjC/NSObject+RACDeallocating.h
+++ b/ReactiveObjC/NSObject+RACDeallocating.h
@@ -12,6 +12,8 @@
 @class RACDisposable;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (RACDeallocating)
 
 /// The compound disposable which will be disposed of when the receiver is
@@ -24,6 +26,8 @@
 - (RACSignal *)rac_willDeallocSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface NSObject (RACUnavailableDeallocating)
 

--- a/ReactiveObjC/NSObject+RACLifting.h
+++ b/ReactiveObjC/NSObject+RACLifting.h
@@ -48,14 +48,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface NSObject (RACUnavailableLifting)
-
-- (RACSignal *)rac_liftSelector:(SEL)selector withObjects:(id)arg, ... __attribute__((unavailable("Use -rac_liftSelector:withSignals: instead")));
-- (RACSignal *)rac_liftSelector:(SEL)selector withObjectsFromArray:(NSArray *)args __attribute__((unavailable("Use -rac_liftSelector:withSignalsFromArray: instead")));
-- (RACSignal *)rac_liftBlock:(id)block withArguments:(id)arg, ... NS_REQUIRES_NIL_TERMINATION __attribute__((unavailable("Use +combineLatest:reduce: instead")));
-- (RACSignal *)rac_liftBlock:(id)block withArgumentsFromArray:(NSArray *)args __attribute__((unavailable("Use +combineLatest:reduce: instead")));
-
-- (instancetype)rac_lift __attribute__((unavailable("Use -rac_liftSelector:withSignals: instead")));
-
-@end

--- a/ReactiveObjC/NSObject+RACLifting.h
+++ b/ReactiveObjC/NSObject+RACLifting.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (RACLifting)
 
 /// Lifts the selector on the receiver into the reactive world. The selector will
@@ -44,6 +46,8 @@
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignalOfArguments:(RACSignal *)arguments;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface NSObject (RACUnavailableLifting)
 

--- a/ReactiveObjC/NSObject+RACPropertySubscribing.h
+++ b/ReactiveObjC/NSObject+RACPropertySubscribing.h
@@ -117,14 +117,3 @@ NS_ASSUME_NONNULL_END
 		(_RACAbleWithStartObject(__VA_ARGS__))
 
 #define _RACAbleWithStartObject(object, property) [object rac_signalWithStartingValueForKeyPath:@keypath(object, property) observer:self]
-
-@interface NSObject (RACUnavailablePropertySubscribing)
-
-+ (RACSignal *)rac_signalFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-+ (RACSignal *)rac_signalWithStartingValueFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-+ (RACSignal *)rac_signalWithChangesFor:(NSObject *)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesAndChangesForKeyPath:options:observer: instead.")));
-- (RACSignal *)rac_signalForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-- (RACSignal *)rac_signalWithStartingValueForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-- (RACDisposable *)rac_deriveProperty:(NSString *)keyPath from:(RACSignal *)signal __attribute__((unavailable("Use -[RACSignal setKeyPath:onObject:] instead")));
-
-@end

--- a/ReactiveObjC/NSObject+RACPropertySubscribing.h
+++ b/ReactiveObjC/NSObject+RACPropertySubscribing.h
@@ -67,6 +67,8 @@
 @class RACDisposable;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSObject (RACPropertySubscribing)
 
 /// Creates a signal to observe the value at the given key path.
@@ -99,6 +101,8 @@
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #define RACAble(...) \
 	metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__)) \

--- a/ReactiveObjC/NSObject+RACSelectorSignal.h
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// The domain for any errors originating from -rac_signalForSelector:.
 extern NSString * const RACSelectorSignalErrorDomain;
 
@@ -77,3 +79,5 @@ extern const NSInteger RACSelectorSignalErrorMethodSwizzlingRace;
 - (RACSignal *)rac_signalForSelector:(SEL)selector fromProtocol:(Protocol *)protocol;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSOrderedSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSOrderedSet+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSOrderedSet (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
@@ -18,3 +20,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSSet+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSSet (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
@@ -18,3 +20,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSString+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSString+RACSequenceAdditions.h
@@ -10,6 +10,8 @@
 
 @class RACSequence;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSString (RACSequenceAdditions)
 
 /// Creates and returns a sequence containing strings corresponding to each
@@ -19,3 +21,5 @@
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSString+RACSupport.h
+++ b/ReactiveObjC/NSString+RACSupport.h
@@ -11,6 +11,8 @@
 @class RACScheduler;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSString (RACSupport)
 
 // Reads in the contents of the file using +[NSString stringWithContentsOfURL:usedEncoding:error:].
@@ -20,3 +22,5 @@
 + (RACSignal<NSString *> *)rac_readContentsOfURL:(NSURL *)URL usedEncoding:(NSStringEncoding *)encoding scheduler:(RACScheduler *)scheduler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSString+RACSupport.m
+++ b/ReactiveObjC/NSString+RACSupport.m
@@ -13,6 +13,8 @@
 @implementation NSString (RACSupport)
 
 + (RACSignal *)rac_readContentsOfURL:(NSURL *)URL usedEncoding:(NSStringEncoding *)encoding scheduler:(RACScheduler *)scheduler {
+	NSCParameterAssert(URL != nil);
+	NSCParameterAssert(encoding != nil);
 	NSCParameterAssert(scheduler != nil);
 	
 	RACReplaySubject *subject = [RACReplaySubject subject];

--- a/ReactiveObjC/NSText+RACSignalSupport.h
+++ b/ReactiveObjC/NSText+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSText (RACSignalSupport)
 
 /// Returns a signal which sends the current `string` of the receiver, then the
@@ -17,3 +19,5 @@
 - (RACSignal<NSString *> *)rac_textSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSURLConnection+RACSupport.h
+++ b/ReactiveObjC/NSURLConnection+RACSupport.h
@@ -11,6 +11,8 @@
 @class RACTuple;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSURLConnection (RACSupport)
 
 // Lazily loads data for the given request in the background.
@@ -24,3 +26,5 @@
 + (RACSignal<RACTuple *> *)rac_sendAsynchronousRequest:(NSURLRequest *)request;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSUserDefaults+RACSupport.h
+++ b/ReactiveObjC/NSUserDefaults+RACSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSUserDefaults (RACSupport)
 
 /// Creates and returns a terminal for binding the user defaults key.
@@ -25,3 +27,5 @@
 - (RACChannelTerminal *)rac_channelTerminalForKey:(NSString *)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/NSUserDefaults+RACSupport.m
+++ b/ReactiveObjC/NSUserDefaults+RACSupport.m
@@ -17,6 +17,8 @@
 @implementation NSUserDefaults (RACSupport)
 
 - (RACChannelTerminal *)rac_channelTerminalForKey:(NSString *)key {
+	NSParameterAssert(key != nil);
+
 	RACChannel *channel = [RACChannel new];
 	
 	RACScheduler *scheduler = [RACScheduler scheduler];

--- a/ReactiveObjC/RACBehaviorSubject.h
+++ b/ReactiveObjC/RACBehaviorSubject.h
@@ -8,11 +8,15 @@
 
 #import "RACSubject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A behavior subject sends the last value it received when it is subscribed to.
 @interface RACBehaviorSubject : RACSubject
 
 /// Creates a new behavior subject with a default value. If it hasn't received
 /// any values when it gets subscribed to, it sends the default value.
-+ (instancetype)behaviorSubjectWithDefaultValue:(id)value;
++ (instancetype)behaviorSubjectWithDefaultValue:(nullable id)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACBlockTrampoline.m
+++ b/ReactiveObjC/RACBlockTrampoline.m
@@ -19,7 +19,6 @@
 
 - (id)initWithBlock:(id)block {
 	self = [super init];
-	if (self == nil) return nil;
 
 	_block = [block copy];
 

--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -50,8 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END
-
 /// Represents one end of a RACChannel.
 ///
 /// An terminal is similar to a socket or pipe -- it represents one end of
@@ -73,3 +71,4 @@ NS_ASSUME_NONNULL_END
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -11,6 +11,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A two-way channel.
 ///
 /// Conceptually, RACChannel can be thought of as a bidirectional connection,
@@ -48,6 +50,8 @@
 
 @end
 
+NS_ASSUME_NONNULL_END
+
 /// Represents one end of a RACChannel.
 ///
 /// An terminal is similar to a socket or pipe -- it represents one end of
@@ -68,3 +72,4 @@
 - (id)init __attribute__((unavailable("Instantiate a RACChannel instead")));
 
 @end
+

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -27,7 +27,6 @@
 
 - (id)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	// We don't want any starting value from the leadingSubject, but we do want
 	// error and completion to be replayed.
@@ -55,7 +54,6 @@
 	NSCParameterAssert(otherTerminal != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_values = values;
 	_otherTerminal = otherTerminal;

--- a/ReactiveObjC/RACCommand.h
+++ b/ReactiveObjC/RACCommand.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACSignal<__covariant ValueType>;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// The domain for errors originating within `RACCommand`.
@@ -110,11 +111,11 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 /// RACCommandErrorNotEnabled.
 - (RACSignal<ValueType> *)execute:(nullable InputType)input;
 
-NS_ASSUME_NONNULL_END
 @end
 
+NS_ASSUME_NONNULL_END
+
 @interface RACCommand (Unavailable)
-NS_ASSUME_NONNULL_BEGIN
 
 @property (atomic, readonly) BOOL canExecute __attribute__((unavailable("Use the 'enabled' signal instead")));
 
@@ -123,5 +124,5 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithCanExecuteSignal:(RACSignal *)canExecuteSignal __attribute__((unavailable("Use -initWithEnabled:signalBlock: instead")));
 - (RACSignal *)addSignalBlock:(RACSignal * (^)(id value))signalBlock __attribute__((unavailable("Pass the signalBlock to -initWithSignalBlock: instead")));
 
-NS_ASSUME_NONNULL_END
 @end
+

--- a/ReactiveObjC/RACCommand.h
+++ b/ReactiveObjC/RACCommand.h
@@ -114,15 +114,3 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface RACCommand (Unavailable)
-
-@property (atomic, readonly) BOOL canExecute __attribute__((unavailable("Use the 'enabled' signal instead")));
-
-+ (instancetype)command __attribute__((unavailable("Use -initWithSignalBlock: instead")));
-+ (instancetype)commandWithCanExecuteSignal:(RACSignal *)canExecuteSignal __attribute__((unavailable("Use -initWithEnabled:signalBlock: instead")));
-- (id)initWithCanExecuteSignal:(RACSignal *)canExecuteSignal __attribute__((unavailable("Use -initWithEnabled:signalBlock: instead")));
-- (RACSignal *)addSignalBlock:(RACSignal * (^)(id value))signalBlock __attribute__((unavailable("Pass the signalBlock to -initWithSignalBlock: instead")));
-
-@end
-

--- a/ReactiveObjC/RACCommand.m
+++ b/ReactiveObjC/RACCommand.m
@@ -83,7 +83,6 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	NSCParameterAssert(signalBlock != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_addedExecutionSignalsSubject = [RACSubject new];
 	_allowsConcurrentExecutionSubject = [RACSubject new];

--- a/ReactiveObjC/RACCompoundDisposable.h
+++ b/ReactiveObjC/RACCompoundDisposable.h
@@ -8,6 +8,8 @@
 
 #import "RACDisposable.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A disposable of disposables. When it is disposed, it disposes of all its
 /// contained disposables.
 ///
@@ -22,7 +24,7 @@
 
 /// Creates and returns a new compound disposable containing the given
 /// disposables.
-+ (instancetype)compoundDisposableWithDisposables:(NSArray *)disposables;
++ (instancetype)compoundDisposableWithDisposables:(nullable NSArray *)disposables;
 
 /// Adds the given disposable. If the receiving disposable has already been
 /// disposed of, the given disposable is disposed immediately.
@@ -31,7 +33,7 @@
 ///
 /// disposable - The disposable to add. This may be nil, in which case nothing
 ///              happens.
-- (void)addDisposable:(RACDisposable *)disposable;
+- (void)addDisposable:(nullable RACDisposable *)disposable;
 
 /// Removes the specified disposable from the compound disposable (regardless of
 /// its disposed status), or does nothing if it's not in the compound disposable.
@@ -43,6 +45,8 @@
 ///
 /// disposable - The disposable to remove. This argument may be nil (to make the
 ///              use of weak references easier).
-- (void)removeDisposable:(RACDisposable *)disposable;
+- (void)removeDisposable:(nullable RACDisposable *)disposable;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACCompoundDisposable.m
+++ b/ReactiveObjC/RACCompoundDisposable.m
@@ -80,7 +80,6 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 
 - (instancetype)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	const int result __attribute__((unused)) = pthread_mutex_init(&_mutex, NULL);
 	NSCAssert(0 == result, @"Failed to initialize mutex with error %d.", result);
@@ -90,7 +89,6 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 
 - (instancetype)initWithDisposables:(NSArray *)otherDisposables {
 	self = [self init];
-	if (self == nil) return nil;
 
 	#if RACCompoundDisposableInlineCount
 	[otherDisposables enumerateObjectsUsingBlock:^(RACDisposable *disposable, NSUInteger index, BOOL *stop) {

--- a/ReactiveObjC/RACDelegateProxy.h
+++ b/ReactiveObjC/RACDelegateProxy.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // A private delegate object suitable for using
 // -rac_signalForSelector:fromProtocol: upon.
 @interface RACDelegateProxy : NSObject
@@ -26,3 +28,5 @@
 - (RACSignal *)signalForSelector:(SEL)selector;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACDelegateProxy.m
+++ b/ReactiveObjC/RACDelegateProxy.m
@@ -25,7 +25,6 @@
 	NSCParameterAssert(protocol != NULL);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	class_addProtocol(self.class, protocol);
 

--- a/ReactiveObjC/RACDisposable.h
+++ b/ReactiveObjC/RACDisposable.h
@@ -10,6 +10,8 @@
 
 @class RACScopedDisposable;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A disposable encapsulates the work necessary to tear down and cleanup a
 /// subscription.
 @interface RACDisposable : NSObject
@@ -33,3 +35,5 @@
 - (RACScopedDisposable *)asScopedDisposable;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACDisposable.m
+++ b/ReactiveObjC/RACDisposable.m
@@ -33,7 +33,6 @@
 
 - (id)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	_disposeBlock = (__bridge void *)self;
 	OSMemoryBarrier();
@@ -45,7 +44,6 @@
 	NSCParameterAssert(block != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_disposeBlock = (void *)CFBridgingRetain([block copy]); 
 	OSMemoryBarrier();

--- a/ReactiveObjC/RACEvent.h
+++ b/ReactiveObjC/RACEvent.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Describes the type of a RACEvent.
 ///
 /// RACEventTypeCompleted - A `completed` event.
@@ -28,10 +30,10 @@ typedef NS_ENUM(NSUInteger, RACEventType) {
 + (instancetype)completedEvent;
 
 /// Returns a new event of type RACEventTypeError, containing the given error.
-+ (instancetype)eventWithError:(NSError *)error;
++ (instancetype)eventWithError:(nullable NSError *)error;
 
 /// Returns a new event of type RACEventTypeNext, containing the given value.
-+ (instancetype)eventWithValue:(id)value;
++ (instancetype)eventWithValue:(nullable id)value;
 
 /// The type of event represented by the receiver.
 @property (nonatomic, assign, readonly) RACEventType eventType;
@@ -42,10 +44,12 @@ typedef NS_ENUM(NSUInteger, RACEventType) {
 
 /// The error associated with an event of type RACEventTypeError. This will be
 /// nil for all other event types.
-@property (nonatomic, strong, readonly) NSError *error;
+@property (nonatomic, strong, readonly, nullable) NSError *error;
 
 /// The value associated with an event of type RACEventTypeNext. This will be
 /// nil for all other event types.
-@property (nonatomic, strong, readonly) id value;
+@property (nonatomic, strong, readonly, nullable) id value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACEvent.m
+++ b/ReactiveObjC/RACEvent.m
@@ -58,7 +58,6 @@
 
 - (id)initWithEventType:(RACEventType)type object:(id)object {
 	self = [super init];
-	if (self == nil) return nil;
 
 	_eventType = type;
 	_object = object;

--- a/ReactiveObjC/RACGroupedSignal.h
+++ b/ReactiveObjC/RACGroupedSignal.h
@@ -8,6 +8,8 @@
 
 #import "RACSubject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A grouped signal is used by -[RACSignal groupBy:transform:].
 @interface RACGroupedSignal : RACSubject
 
@@ -17,3 +19,5 @@
 + (instancetype)signalWithKey:(id<NSCopying>)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACKVOChannel.h
+++ b/ReactiveObjC/RACKVOChannel.h
@@ -60,6 +60,8 @@
 #define RACChannelTo_(TARGET, KEYPATH, NILVALUE) \
     [[RACKVOChannel alloc] initWithTarget:(TARGET) keyPath:@keypath(TARGET, KEYPATH) nilValue:(NILVALUE)][@keypath(RACKVOChannel.new, followingTerminal)]
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A RACChannel that observes a KVO-compliant key path for changes.
 @interface RACKVOChannel : RACChannel
 
@@ -83,10 +85,10 @@
 ///            exception if `nil` is received (which might occur if an intermediate
 ///            object is set to `nil`).
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
-- (id)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(id)nilValue;
+- (id)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
 #else
 // Swift builds with OS_OBJECT_HAVE_OBJC_SUPPORT=0 for Playgrounds and LLDB :(
-- (id)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(id)nilValue;
+- (id)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
 #endif
 
 - (id)init __attribute__((unavailable("Use -initWithTarget:keyPath:nilValue: instead")));
@@ -100,3 +102,6 @@
 - (void)setObject:(RACChannelTerminal *)otherTerminal forKeyedSubscript:(NSString *)key;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/ReactiveObjC/RACKVOChannel.m
+++ b/ReactiveObjC/RACKVOChannel.m
@@ -75,7 +75,6 @@ static NSString * const RACKVOChannelDataDictionaryKey = @"RACKVOChannelKey";
 	NSObject *strongTarget = target;
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_target = target;
 	_keyPath = [keyPath copy];

--- a/ReactiveObjC/RACKVOProxy.m
+++ b/ReactiveObjC/RACKVOProxy.m
@@ -30,7 +30,6 @@
 
 - (instancetype)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	_queue = dispatch_queue_create("org.reactivecocoa.ReactiveObjC.RACKVOProxy", DISPATCH_QUEUE_SERIAL);
 	_trampolines = [NSMapTable strongToWeakObjectsMapTable];

--- a/ReactiveObjC/RACKVOTrampoline.m
+++ b/ReactiveObjC/RACKVOTrampoline.m
@@ -37,7 +37,6 @@
 	if (strongTarget == nil) return nil;
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_keyPath = [keyPath copy];
 

--- a/ReactiveObjC/RACMulticastConnection.h
+++ b/ReactiveObjC/RACMulticastConnection.h
@@ -11,6 +11,8 @@
 @class RACDisposable;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A multicast connection encapsulates the idea of sharing one subscription to a
 /// signal to many subscribers. This is most often needed if the subscription to
 /// the underlying signal involves side-effects or shouldn't be called more than
@@ -46,3 +48,5 @@
 - (RACSignal *)autoconnect;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACMulticastConnection.m
+++ b/ReactiveObjC/RACMulticastConnection.m
@@ -40,7 +40,6 @@
 	NSCParameterAssert(subject != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_sourceSignal = source;
 	_serialDisposable = [[RACSerialDisposable alloc] init];

--- a/ReactiveObjC/RACPassthroughSubscriber.m
+++ b/ReactiveObjC/RACPassthroughSubscriber.m
@@ -56,7 +56,6 @@ static const char *cleanedSignalDescription(RACSignal *signal) {
 	NSCParameterAssert(subscriber != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_innerSubscriber = subscriber;
 	_signal = signal;

--- a/ReactiveObjC/RACQueueScheduler+Subclass.h
+++ b/ReactiveObjC/RACQueueScheduler+Subclass.h
@@ -9,6 +9,8 @@
 #import "RACQueueScheduler.h"
 #import "RACScheduler+Subclass.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An interface for use by GCD queue-based subclasses.
 ///
 /// See RACScheduler+Subclass.h for subclassing notes.
@@ -30,7 +32,7 @@
 ///         This argument must not be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithName:(NSString *)name queue:(dispatch_queue_t)queue;
+- (id)initWithName:(nullable NSString *)name queue:(dispatch_queue_t)queue;
 
 /// Converts a date into a GCD time using dispatch_walltime().
 ///
@@ -38,3 +40,5 @@
 + (dispatch_time_t)wallTimeWithDate:(NSDate *)date;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACQueueScheduler.h
+++ b/ReactiveObjC/RACQueueScheduler.h
@@ -8,6 +8,8 @@
 
 #import "RACScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An abstract scheduler which asynchronously enqueues all its work to a Grand
 /// Central Dispatch queue.
 ///
@@ -16,3 +18,5 @@
 /// interface and use that instead.
 @interface RACQueueScheduler : RACScheduler
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACQueueScheduler.m
+++ b/ReactiveObjC/RACQueueScheduler.m
@@ -19,7 +19,6 @@
 	NSCParameterAssert(queue != NULL);
 
 	self = [super initWithName:name];
-	if (self == nil) return nil;
 
 	_queue = queue;
 #if !OS_OBJECT_USE_OBJC

--- a/ReactiveObjC/RACReplaySubject.h
+++ b/ReactiveObjC/RACReplaySubject.h
@@ -8,6 +8,8 @@
 
 #import "RACSubject.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern const NSUInteger RACReplaySubjectUnlimitedCapacity;
 
 /// A replay subject saves the values it is sent (up to its defined capacity)
@@ -20,3 +22,5 @@ extern const NSUInteger RACReplaySubjectUnlimitedCapacity;
 + (instancetype)replaySubjectWithCapacity:(NSUInteger)capacity;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACReplaySubject.m
+++ b/ReactiveObjC/RACReplaySubject.m
@@ -42,7 +42,6 @@ const NSUInteger RACReplaySubjectUnlimitedCapacity = NSUIntegerMax;
 
 - (instancetype)initWithCapacity:(NSUInteger)capacity {
 	self = [super init];
-	if (self == nil) return nil;
 	
 	_capacity = capacity;
 	_valuesReceived = (capacity == RACReplaySubjectUnlimitedCapacity ? [NSMutableArray array] : [NSMutableArray arrayWithCapacity:capacity]);

--- a/ReactiveObjC/RACScheduler+Private.h
+++ b/ReactiveObjC/RACScheduler+Private.h
@@ -8,6 +8,8 @@
 
 #import "RACScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // The thread-specific current scheduler key.
 extern NSString * const RACSchedulerCurrentSchedulerKey;
 
@@ -29,6 +31,8 @@ extern NSString * const RACSchedulerCurrentSchedulerKey;
 // name - The name of the scheduler. If nil, a default name will be used.
 //
 // Returns the initialized object.
-- (id)initWithName:(NSString *)name;
+- (id)initWithName:(nullable NSString *)name;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACScheduler+Subclass.h
+++ b/ReactiveObjC/RACScheduler+Subclass.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "RACScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// An interface for use by subclasses.
 ///
 /// Subclasses should use `-performAsCurrentScheduler:` to do the actual block
@@ -27,3 +29,5 @@
 - (void)performAsCurrentScheduler:(void (^)(void))block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACScheduler.h
+++ b/ReactiveObjC/RACScheduler.h
@@ -58,7 +58,7 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 
 /// The current scheduler. This will only be valid when used from within a
 /// -[RACScheduler schedule:] block or when on the main thread.
-+ (RACScheduler *)currentScheduler;
++ (nullable RACScheduler *)currentScheduler;
 
 /// Schedule the given block for execution on the scheduler.
 ///

--- a/ReactiveObjC/RACScheduler.h
+++ b/ReactiveObjC/RACScheduler.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// The priority for the scheduler.
 ///
 /// RACSchedulerPriorityHigh       - High priority.
@@ -46,7 +48,7 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 /// Scheduler creation is cheap. It's unnecessary to save the result of this
 /// method call unless you want to serialize some actions on the same background
 /// scheduler.
-+ (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority name:(NSString *)name;
++ (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority name:(nullable NSString *)name;
 
 /// Invokes +schedulerWithPriority:name: with a default name.
 + (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority;
@@ -66,7 +68,7 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 ///
 /// Returns a disposable which can be used to cancel the scheduled block before
 /// it begins executing, or nil if cancellation is not supported.
-- (RACDisposable *)schedule:(void (^)(void))block;
+- (nullable RACDisposable *)schedule:(void (^)(void))block;
 
 /// Schedule the given block for execution on the scheduler at or after
 /// a specific time.
@@ -84,12 +86,12 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 ///
 /// Returns a disposable which can be used to cancel the scheduled block before
 /// it begins executing, or nil if cancellation is not supported.
-- (RACDisposable *)after:(NSDate *)date schedule:(void (^)(void))block;
+- (nullable RACDisposable *)after:(NSDate *)date schedule:(void (^)(void))block;
 
 /// Schedule the given block for execution on the scheduler after the delay.
 ///
 /// Converts the delay into an NSDate, then invokes `-after:schedule:`.
-- (RACDisposable *)afterDelay:(NSTimeInterval)delay schedule:(void (^)(void))block;
+- (nullable RACDisposable *)afterDelay:(NSTimeInterval)delay schedule:(void (^)(void))block;
 
 /// Reschedule the given block at a particular interval, starting at a specific
 /// time, and with a given leeway for deferral.
@@ -118,7 +120,7 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 ///
 /// Returns a disposable which can be used to cancel the automatic scheduling and
 /// rescheduling, or nil if cancellation is not supported.
-- (RACDisposable *)after:(NSDate *)date repeatingEvery:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway schedule:(void (^)(void))block;
+- (nullable RACDisposable *)after:(NSDate *)date repeatingEvery:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway schedule:(void (^)(void))block;
 
 /// Schedule the given recursive block for execution on the scheduler. The
 /// scheduler will automatically flatten any recursive scheduling into iteration
@@ -137,9 +139,11 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 /// Returns a disposable which can be used to cancel the scheduled block before
 /// it begins executing, or to stop it from rescheduling if it's already begun
 /// execution.
-- (RACDisposable *)scheduleRecursiveBlock:(RACSchedulerRecursiveBlock)recursiveBlock;
+- (nullable RACDisposable *)scheduleRecursiveBlock:(RACSchedulerRecursiveBlock)recursiveBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface RACScheduler (Unavailable)
 

--- a/ReactiveObjC/RACScheduler.h
+++ b/ReactiveObjC/RACScheduler.h
@@ -144,9 +144,3 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface RACScheduler (Unavailable)
-
-+ (RACScheduler *)schedulerWithQueue:(dispatch_queue_t)queue name:(NSString *)name __attribute__((unavailable("Use -[RACTargetQueueScheduler initWithName:targetQueue:] instead.")));
-
-@end

--- a/ReactiveObjC/RACScheduler.m
+++ b/ReactiveObjC/RACScheduler.m
@@ -33,7 +33,6 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 
 - (id)initWithName:(NSString *)name {
 	self = [super init];
-	if (self == nil) return nil;
 
 	if (name == nil) {
 		_name = [NSString stringWithFormat:@"org.reactivecocoa.ReactiveObjC.%@.anonymousScheduler", self.class];

--- a/ReactiveObjC/RACScopedDisposable.h
+++ b/ReactiveObjC/RACScopedDisposable.h
@@ -8,6 +8,8 @@
 
 #import "RACDisposable.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A disposable that calls its own -dispose when it is dealloc'd.
 @interface RACScopedDisposable : RACDisposable
 
@@ -16,3 +18,5 @@
 + (instancetype)scopedDisposableWithDisposable:(RACDisposable *)disposable;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -12,6 +12,8 @@
 @class RACScheduler;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Represents an immutable sequence of values. Unless otherwise specified, the
 /// sequences' values are evaluated lazily on demand. Like Cocoa collections,
 /// sequences cannot contain nil.
@@ -28,13 +30,13 @@
 /// The first object in the sequence, or nil if the sequence is empty.
 ///
 /// Subclasses must provide an implementation of this method.
-@property (nonatomic, strong, readonly) id head;
+@property (nonatomic, strong, readonly, nullable) id head;
 
 /// All but the first object in the sequence, or nil if there are no other
 /// objects.
 ///
 /// Subclasses must provide an implementation of this method.
-@property (nonatomic, strong, readonly) RACSequence *tail;
+@property (nonatomic, strong, readonly, nullable) RACSequence *tail;
 
 /// Evaluates the full sequence to produce an equivalently-sized array.
 @property (nonatomic, copy, readonly) NSArray *array;
@@ -84,7 +86,7 @@
 ///          Cannot be nil.
 ///
 /// Returns a reduced value.
-- (id)foldLeftWithStart:(id)start reduce:(id (^)(id accumulator, id value))reduce;
+- (id)foldLeftWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable accumulator, id _Nullable value))reduce;
 
 /// Applies a right fold to the sequence.
 ///
@@ -103,28 +105,28 @@
 ///          don't need to.
 ///
 /// Returns a reduced value.
-- (id)foldRightWithStart:(id)start reduce:(id (^)(id first, RACSequence *rest))reduce;
+- (id)foldRightWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable first, RACSequence *rest))reduce;
 
 /// Check if any value in sequence passes the block.
 ///
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns a boolean indiciating if any value in the sequence passed.
-- (BOOL)any:(BOOL (^)(id value))block;
+- (BOOL)any:(BOOL (^)(id _Nullable value))block;
 
 /// Check if all values in the sequence pass the block.
 ///
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns a boolean indicating if all values in the sequence passed.
-- (BOOL)all:(BOOL (^)(id value))block;
+- (BOOL)all:(BOOL (^)(id _Nullable value))block;
 
 /// Returns the first object that passes the block.
 ///
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns an object that passes the block or nil if no objects passed.
-- (id)objectPassingTest:(BOOL (^)(id value))block;
+- (id)objectPassingTest:(BOOL (^)(id _Nullable value))block;
 
 /// Creates a sequence that dynamically generates its values.
 ///
@@ -143,9 +145,11 @@
 ///
 /// Returns a sequence that lazily invokes the given blocks to provide head and
 /// tail. `headBlock` must not be nil.
-+ (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock;
++ (RACSequence *)sequenceWithHeadBlock:(id _Nullable (^)(void))headBlock tailBlock:(nullable RACSequence *(^)(void))tailBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface RACSequence (Unavailable)
 

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -150,10 +150,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface RACSequence (Unavailable)
-
-- (id)foldLeftWithStart:(id)start combine:(id (^)(id accumulator, id value))combine __attribute__((unavailable("Renamed to -foldLeftWithStart:reduce:")));
-- (id)foldRightWithStart:(id)start combine:(id (^)(id first, RACSequence *rest))combine __attribute__((unavailable("Renamed to -foldRightWithStart:reduce:")));
-
-@end

--- a/ReactiveObjC/RACSerialDisposable.h
+++ b/ReactiveObjC/RACSerialDisposable.h
@@ -8,6 +8,8 @@
 
 #import "RACDisposable.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A disposable that contains exactly one other disposable and allows it to be
 /// swapped out atomically.
 @interface RACSerialDisposable : RACDisposable
@@ -22,14 +24,14 @@
 /// this property, then set the property to nil. If any new disposable is set
 /// after the receiver is disposed, it will be disposed immediately and this
 /// property will remain set to nil.
-@property (atomic, strong) RACDisposable *disposable;
+@property (atomic, strong, nullable) RACDisposable *disposable;
 
 /// Creates a serial disposable which will wrap the given disposable.
 ///
 /// disposable - The value to set for `disposable`. This may be nil.
 ///
-/// Returns a RACSerialDisposable, or nil if an error occurs.
-+ (instancetype)serialDisposableWithDisposable:(RACDisposable *)disposable;
+/// Returns a RACSerialDisposable.
++ (instancetype)serialDisposableWithDisposable:(nullable RACDisposable *)disposable;
 
 /// Atomically swaps the receiver's `disposable` for `newDisposable`.
 ///
@@ -38,6 +40,8 @@
 ///                 will remain set to nil. This argument may be nil.
 ///
 /// Returns the previous value for the `disposable` property.
-- (RACDisposable *)swapInDisposable:(RACDisposable *)newDisposable;
+- (nullable RACDisposable *)swapInDisposable:(nullable RACDisposable *)newDisposable;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -9,16 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "RACSignal.h"
 
-/// The domain for errors originating in RACSignal operations.
-extern NSString * _Nonnull const RACSignalErrorDomain;
-
-/// The error code used with -timeout:.
-extern const NSInteger RACSignalErrorTimedOut;
-
-/// The error code used when a value passed into +switch:cases:default: does not
-/// match any of the cases, and no default was given.
-extern const NSInteger RACSignalErrorNoMatchingCase;
-
 @class RACCommand;
 @class RACDisposable;
 @class RACMulticastConnection;
@@ -28,8 +18,19 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 @class RACTuple;
 @protocol RACSubscriber;
 
-@interface RACSignal (Operations)
 NS_ASSUME_NONNULL_BEGIN
+
+/// The domain for errors originating in RACSignal operations.
+extern NSString * const RACSignalErrorDomain;
+
+/// The error code used with -timeout:.
+extern const NSInteger RACSignalErrorTimedOut;
+
+/// The error code used when a value passed into +switch:cases:default: does not
+/// match any of the cases, and no default was given.
+extern const NSInteger RACSignalErrorNoMatchingCase;
+
+@interface RACSignal (Operations)
 
 /// Do the given block on `next`. This should be used to inject side effects into
 /// the signal.
@@ -704,8 +705,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// to the remaining elements.
 - (RACSignal *)reduceApply;
 
-NS_ASSUME_NONNULL_END
 @end
+
+NS_ASSUME_NONNULL_END
 
 @interface RACSignal (UnavailableOperations)
 NS_ASSUME_NONNULL_BEGIN

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -708,23 +708,3 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface RACSignal (UnavailableOperations)
-NS_ASSUME_NONNULL_BEGIN
-
-- (RACSignal *)windowWithStart:(RACSignal *)openSignal close:(RACSignal * (^)(RACSignal *start))closeBlock __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
-- (RACSignal *)buffer:(NSUInteger)bufferCount __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
-- (RACSignal *)let:(RACSignal * (^)(RACSignal *sharedSignal))letBlock __attribute__((unavailable("Use -publish instead")));
-+ (RACSignal *)interval:(NSTimeInterval)interval __attribute__((unavailable("Use +interval:onScheduler: instead")));
-+ (RACSignal *)interval:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway __attribute__((unavailable("Use +interval:onScheduler:withLeeway: instead")));
-- (RACSignal *)bufferWithTime:(NSTimeInterval)interval __attribute__((unavailable("Use -bufferWithTime:onScheduler: instead")));
-- (RACSignal *)timeout:(NSTimeInterval)interval __attribute__((unavailable("Use -timeout:onScheduler: instead")));
-- (RACDisposable *)toProperty:(NSString *)keyPath onObject:(NSObject *)object __attribute__((unavailable("Renamed to -setKeyPath:onObject:")));
-- (RACSignal *)ignoreElements __attribute__((unavailable("Renamed to -ignoreValues")));
-- (RACSignal *)sequenceNext:(RACSignal * (^)(void))block __attribute__((unavailable("Renamed to -then:")));
-- (RACSignal *)aggregateWithStart:(nullable id)start combine:(id _Nullable (^)(id _Nullable running, id _Nullable next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStart:reduce:")));
-- (RACSignal *)aggregateWithStartFactory:(id _Nullable (^)(void))startFactory combine:(id _Nullable (^)(id _Nullable running, id _Nullable next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStartFactory:reduce:")));
-- (RACDisposable *)executeCommand:(RACCommand *)command __attribute__((unavailable("Use -flattenMap: or -subscribeNext: instead")));
-
-NS_ASSUME_NONNULL_END
-@end

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -14,8 +14,9 @@
 @class RACSubject;
 @protocol RACSubscriber;
 
-@interface RACSignal<__covariant ValueType> : RACStream
 NS_ASSUME_NONNULL_BEGIN
+
+@interface RACSignal<__covariant ValueType> : RACStream
 
 /// Creates a new signal. This is the preferred way to create a new signal
 /// operation or behavior.
@@ -209,15 +210,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// `error` will be set to any error that occurred.
 - (BOOL)asynchronouslyWaitUntilCompleted:(NSError * _Nullable * _Nullable)error;
 
-NS_ASSUME_NONNULL_END
 @end
 
+NS_ASSUME_NONNULL_END
+
 @interface RACSignal (Unavailable)
-NS_ASSUME_NONNULL_BEGIN
 
 + (RACSignal *)start:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 + (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 + (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 
-NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -213,11 +213,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface RACSignal (Unavailable)
-
-+ (RACSignal *)start:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-+ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-+ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-
-@end

--- a/ReactiveObjC/RACStream.h
+++ b/ReactiveObjC/RACStream.h
@@ -10,12 +10,14 @@
 
 @class RACStream;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A block which accepts a value from a RACStream and returns a new instance
 /// of the same stream class.
 ///
 /// Setting `stop` to `YES` will cause the bind to terminate after the returned
 /// value. Returning `nil` will result in immediate termination.
-typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
+typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *stop);
 
 /// An abstract class representing any stream of values.
 ///
@@ -32,7 +34,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 /// Lifts `value` into the stream monad.
 ///
 /// Returns a stream containing only the given value.
-+ (instancetype)return:(id)value;
++ (instancetype)return:(nullable id)value;
 
 /// Lazily binds a block to the values in the receiver.
 ///
@@ -122,7 +124,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream which represents the combined streams resulting from
 /// mapping `block`.
-- (instancetype)flattenMap:(RACStream * (^)(id value))block;
+- (instancetype)flattenMap:(RACStream * _Nullable (^)(id _Nullable value))block;
 
 /// Flattens a stream of streams.
 ///
@@ -137,20 +139,20 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 /// This corresponds to the `Select` method in Rx.
 ///
 /// Returns a new stream with the mapped values.
-- (instancetype)map:(id (^)(id value))block;
+- (instancetype)map:(id _Nullable (^)(id _Nullable value))block;
 
 /// Replaces each value in the receiver with the given object.
 ///
 /// Returns a new stream which includes the given object once for each value in
 /// the receiver.
-- (instancetype)mapReplace:(id)object;
+- (instancetype)mapReplace:(nullable id)object;
 
 /// Filters out values in the receiver that don't pass the given test.
 ///
 /// This corresponds to the `Where` method in Rx.
 ///
 /// Returns a new stream with only those values that passed.
-- (instancetype)filter:(BOOL (^)(id value))block;
+- (instancetype)filter:(BOOL (^)(id _Nullable value))block;
 
 /// Filters out values in the receiver that equal (via -isEqual:) the provided value.
 ///
@@ -158,7 +160,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream containing only the values which did not compare equal
 /// to `value`.
-- (instancetype)ignore:(id)value;
+- (instancetype)ignore:(nullable id)value;
 
 /// Unpacks each RACTuple in the receiver and maps the values to a new value.
 ///
@@ -168,11 +170,11 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///               return value must be an object. This argument cannot be nil.
 ///
 /// Returns a new stream of reduced tuple values.
-- (instancetype)reduceEach:(id (^)())reduceBlock;
+- (instancetype)reduceEach:(id _Nullable (^)())reduceBlock;
 
 /// Returns a stream consisting of `value`, followed by the values in the
 /// receiver.
-- (instancetype)startWith:(id)value;
+- (instancetype)startWith:(nullable id)value;
 
 /// Skips the first `skipCount` values in the receiver.
 ///
@@ -219,7 +221,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream containing the results from each invocation of
 /// `reduceBlock`.
-+ (instancetype)zip:(id<NSFastEnumeration>)streams reduce:(id (^)())reduceBlock;
++ (instancetype)zip:(id<NSFastEnumeration>)streams reduce:(id _Nullable (^)())reduceBlock;
 
 /// Returns a stream obtained by concatenating `streams` in order.
 + (instancetype)concat:(id<NSFastEnumeration>)streams;
@@ -252,7 +254,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream that consists of each application of `reduceBlock`. If the
 /// receiver is empty, an empty stream is returned.
-- (instancetype)scanWithStart:(id)startingValue reduce:(id (^)(id running, id next))reduceBlock;
+- (instancetype)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, id _Nullable next))reduceBlock;
 
 /// Combines values in the receiver from left to right using the given block
 /// which also takes zero-based index of the values.
@@ -266,7 +268,7 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream that consists of each application of `reduceBlock`. If the
 /// receiver is empty, an empty stream is returned.
-- (instancetype)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id running, id next, NSUInteger index))reduceBlock;
+- (instancetype)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, id _Nullable next, NSUInteger index))reduceBlock;
 
 /// Combines each previous and current value into one object.
 ///
@@ -290,35 +292,35 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 ///
 /// Returns a new stream consisting of the return values from each application of
 /// `reduceBlock`.
-- (instancetype)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id current))reduceBlock;
+- (instancetype)combinePreviousWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable previous, id _Nullable current))reduceBlock;
 
 /// Takes values until the given block returns `YES`.
 ///
 /// Returns a stream of the initial values in the receiver that fail `predicate`.
 /// If `predicate` never returns `YES`, a stream equivalent to the receiver is
 /// returned.
-- (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate;
+- (instancetype)takeUntilBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Takes values until the given block returns `NO`.
 ///
 /// Returns a stream of the initial values in the receiver that pass `predicate`.
 /// If `predicate` never returns `NO`, a stream equivalent to the receiver is
 /// returned.
-- (instancetype)takeWhileBlock:(BOOL (^)(id x))predicate;
+- (instancetype)takeWhileBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Skips values until the given block returns `YES`.
 ///
 /// Returns a stream containing the values of the receiver that follow any
 /// initial values failing `predicate`. If `predicate` never returns `YES`,
 /// an empty stream is returned.
-- (instancetype)skipUntilBlock:(BOOL (^)(id x))predicate;
+- (instancetype)skipUntilBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Skips values until the given block returns `NO`.
 ///
 /// Returns a stream containing the values of the receiver that follow any
 /// initial values passing `predicate`. If `predicate` never returns `NO`, an
 /// empty stream is returned.
-- (instancetype)skipWhileBlock:(BOOL (^)(id x))predicate;
+- (instancetype)skipWhileBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Returns a stream of values for which -isEqual: returns NO when compared to the
 /// previous value.
@@ -326,10 +328,4 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 
 @end
 
-@interface RACStream (Unavailable)
-
-- (instancetype)sequenceMany:(RACStream * (^)(void))block __attribute__((unavailable("Use -flattenMap: instead")));
-- (instancetype)scanWithStart:(id)startingValue combine:(id (^)(id running, id next))block __attribute__((unavailable("Renamed to -scanWithStart:reduce:")));
-- (instancetype)mapPreviousWithStart:(id)start reduce:(id (^)(id previous, id current))combineBlock __attribute__((unavailable("Renamed to -combinePreviousWithStart:reduce:")));
-
-@end
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACStream.m
+++ b/ReactiveObjC/RACStream.m
@@ -17,7 +17,6 @@
 
 - (id)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	self.name = @"";
 	return self;

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -9,6 +9,8 @@
 #import "RACSignal.h"
 #import "RACSubscriber.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A subject can be thought of as a signal that you can manually control by
 /// sending next, completed, and error.
 ///
@@ -20,3 +22,5 @@
 + (instancetype)subject;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSubscriber.m
+++ b/ReactiveObjC/RACSubscriber.m
@@ -38,7 +38,6 @@
 
 - (id)init {
 	self = [super init];
-	if (self == nil) return nil;
 
 	@unsafeify(self);
 

--- a/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
@@ -11,6 +11,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Assigns a signal to an object property, automatically setting the given key
 /// path on every `next`. When the signal completes, the binding is automatically
 /// disposed of.
@@ -48,7 +50,9 @@
 
 @interface RACSubscriptingAssignmentTrampoline : NSObject
 
-- (id)initWithTarget:(id)target nilValue:(id)nilValue;
+- (nullable id)initWithTarget:(nullable id)target nilValue:(nullable id)nilValue;
 - (void)setObject:(RACSignal *)signal forKeyedSubscript:(NSString *)keyPath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSubscriptionScheduler.h
+++ b/ReactiveObjC/RACSubscriptionScheduler.h
@@ -8,8 +8,12 @@
 
 #import "RACScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // A private scheduler used only for subscriptions. See the private
 // +[RACScheduler subscriptionScheduler] method for more information.
 @interface RACSubscriptionScheduler : RACScheduler
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSubscriptionScheduler.m
+++ b/ReactiveObjC/RACSubscriptionScheduler.m
@@ -23,7 +23,6 @@
 
 - (id)init {
 	self = [super initWithName:@"org.reactivecocoa.ReactiveObjC.RACScheduler.subscriptionScheduler"];
-	if (self == nil) return nil;
 
 	_backgroundScheduler = [RACScheduler scheduler];
 

--- a/ReactiveObjC/RACTargetQueueScheduler.h
+++ b/ReactiveObjC/RACTargetQueueScheduler.h
@@ -8,6 +8,8 @@
 
 #import "RACQueueScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A scheduler that enqueues blocks on a private serial queue, targeting an
 /// arbitrary GCD queue.
 @interface RACTargetQueueScheduler : RACQueueScheduler
@@ -19,6 +21,8 @@
 /// targetQueue - The queue to target. Cannot be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithName:(NSString *)name targetQueue:(dispatch_queue_t)targetQueue;
+- (id)initWithName:(nullable NSString *)name targetQueue:(dispatch_queue_t)targetQueue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACTestScheduler.h
+++ b/ReactiveObjC/RACTestScheduler.h
@@ -8,6 +8,8 @@
 
 #import "RACScheduler.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A special kind of scheduler that steps through virtualized time.
 ///
 /// This scheduler class can be used in unit tests to verify asynchronous
@@ -40,3 +42,5 @@
 - (void)stepAll;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACTestScheduler.m
+++ b/ReactiveObjC/RACTestScheduler.m
@@ -74,7 +74,6 @@ static void RACReleaseScheduledAction(CFAllocatorRef allocator, const void *ptr)
 
 - (instancetype)init {
 	self = [super initWithName:@"org.reactivecocoa.ReactiveObjC.RACTestScheduler"];
-	if (self == nil) return nil;
 
 	CFBinaryHeapCallBacks callbacks = (CFBinaryHeapCallBacks){
 		.version = 0,
@@ -205,7 +204,6 @@ static void RACReleaseScheduledAction(CFAllocatorRef allocator, const void *ptr)
 	NSCParameterAssert(block != nil);
 
 	self = [super init];
-	if (self == nil) return nil;
 
 	_date = [date copy];
 	_block = [block copy];

--- a/ReactiveObjC/RACTuple.h
+++ b/ReactiveObjC/RACTuple.h
@@ -43,6 +43,8 @@
 #define RACTupleUnpack(...) \
         RACTupleUnpack_(__VA_ARGS__)
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A sentinel object that represents nils in the tuple.
 ///
 /// It should never be necessary to create a tuple nil yourself. Just use
@@ -61,12 +63,12 @@
 
 /// These properties all return the object at that index or nil if the number of 
 /// objects is less than the index.
-@property (nonatomic, readonly) id first;
-@property (nonatomic, readonly) id second;
-@property (nonatomic, readonly) id third;
-@property (nonatomic, readonly) id fourth;
-@property (nonatomic, readonly) id fifth;
-@property (nonatomic, readonly) id last;
+@property (nonatomic, readonly, nullable) id first;
+@property (nonatomic, readonly, nullable) id second;
+@property (nonatomic, readonly, nullable) id third;
+@property (nonatomic, readonly, nullable) id fourth;
+@property (nonatomic, readonly, nullable) id fifth;
+@property (nonatomic, readonly, nullable) id last;
 
 /// Creates a new tuple out of the array. Does not convert nulls to nils.
 + (instancetype)tupleWithObjectsFromArray:(NSArray *)array;
@@ -82,7 +84,7 @@
 /// Returns the object at `index` or nil if the object is a RACTupleNil. Unlike
 /// NSArray and friends, it's perfectly fine to ask for the object at an index
 /// past the tuple's count - 1. It will simply return nil.
-- (id)objectAtIndex:(NSUInteger)index;
+- (nullable id)objectAtIndex:(NSUInteger)index;
 
 /// Returns an array of all the objects. RACTupleNils are converted to NSNulls.
 - (NSArray *)allObjects;
@@ -92,7 +94,7 @@
 /// obj - The object to add to the tuple. This argument may be nil.
 ///
 /// Returns a new tuple.
-- (instancetype)tupleByAddingObject:(id)obj;
+- (instancetype)tupleByAddingObject:(nullable id)obj;
 
 @end
 
@@ -106,7 +108,7 @@
 @interface RACTuple (ObjectSubscripting)
 /// Returns the object at that index or nil if the number of objects is less
 /// than the index.
-- (id)objectAtIndexedSubscript:(NSUInteger)idx; 
+- (nullable id)objectAtIndexedSubscript:(NSUInteger)idx;
 @end
 
 /// This and everything below is for internal use only.
@@ -154,6 +156,8 @@
 @interface RACTupleUnpackingTrampoline : NSObject
 
 + (instancetype)trampoline;
-- (void)setObject:(RACTuple *)tuple forKeyedSubscript:(NSArray *)variables;
+- (void)setObject:(nullable RACTuple *)tuple forKeyedSubscript:(NSArray *)variables;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -50,7 +50,6 @@
 
 - (instancetype)init {
 	self = [super init];
-	if (self == nil) return nil;
 	
 	self.backingArray = [NSArray array];
 	
@@ -92,7 +91,6 @@
 
 - (id)initWithCoder:(NSCoder *)coder {
 	self = [self init];
-	if (self == nil) return nil;
 	
 	self.backingArray = [coder decodeObjectForKey:@keypath(self.backingArray)];
 	return self;

--- a/ReactiveObjC/RACUnit.h
+++ b/ReactiveObjC/RACUnit.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// A unit represents an empty value.
 ///
 /// It should never be necessary to create a unit yourself. Just use +defaultUnit.
@@ -17,3 +19,5 @@
 + (RACUnit *)defaultUnit;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIActionSheet+RACSignalSupport.h
+++ b/ReactiveObjC/UIActionSheet+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACDelegateProxy;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIActionSheet (RACSignalSupport)
 
 /// A delegate proxy which will be set as the receiver's delegate when any of the
@@ -30,3 +32,5 @@
 - (RACSignal<NSNumber *> *)rac_buttonClickedSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIAlertView+RACSignalSupport.h
+++ b/ReactiveObjC/UIAlertView+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACDelegateProxy;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIAlertView (RACSignalSupport)
 
 /// A delegate proxy which will be set as the receiver's delegate when any of the
@@ -45,3 +47,5 @@
 - (RACSignal<NSNumber *> *)rac_willDismissSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIBarButtonItem+RACCommandSupport.h
+++ b/ReactiveObjC/UIBarButtonItem+RACCommandSupport.h
@@ -10,6 +10,8 @@
 
 @class RACCommand<__contravariant InputType, __covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIBarButtonItem (RACCommandSupport)
 
 /// Sets the control's command. When the control is clicked, the command is
@@ -17,6 +19,8 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand<__kindof UIBarButtonItem *, id> *rac_command;
+@property (nonatomic, strong, nullable) RACCommand<__kindof UIBarButtonItem *, id> *rac_command;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIButton+RACCommandSupport.h
+++ b/ReactiveObjC/UIButton+RACCommandSupport.h
@@ -10,11 +10,15 @@
 
 @class RACCommand<__contravariant InputType, __covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIButton (RACCommandSupport)
 
 /// Sets the button's command. When the button is clicked, the command is
 /// executed with the sender of the event. The button's enabledness is bound
 /// to the command's `canExecute`.
-@property (nonatomic, strong) RACCommand<__kindof UIButton *, id> *rac_command;
+@property (nonatomic, strong, nullable) RACCommand<__kindof UIButton *, id> *rac_command;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UICollectionReusableView+RACSignalSupport.h
+++ b/ReactiveObjC/UICollectionReusableView+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACSignal<__covariant ValueType>;
 @class RACUnit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // This category is only applicable to iOS >= 6.0.
 @interface UICollectionReusableView (RACSignalSupport)
 
@@ -28,3 +30,5 @@
 @property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIControl+RACSignalSupport.h
+++ b/ReactiveObjC/UIControl+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIControl (RACSignalSupport)
 
 /// Creates and returns a signal that sends the sender of the control event
@@ -17,3 +19,5 @@
 - (RACSignal<__kindof UIControl *> *)rac_signalForControlEvents:(UIControlEvents)controlEvents;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIDatePicker+RACSignalSupport.h
+++ b/ReactiveObjC/UIDatePicker+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIDatePicker (RACSignalSupport)
 
 /// Creates a new RACChannel-based binding to the receiver.
@@ -19,6 +21,8 @@
 /// Returns a RACChannelTerminal that sends the receiver's date whenever the
 /// UIControlEventValueChanged control event is fired, and sets the date to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newDateChannelWithNilValue:(NSDate *)nilValue;
+- (RACChannelTerminal *)rac_newDateChannelWithNilValue:(nullable NSDate *)nilValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIGestureRecognizer+RACSignalSupport.h
+++ b/ReactiveObjC/UIGestureRecognizer+RACSignalSupport.h
@@ -10,9 +10,13 @@
 
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIGestureRecognizer (RACSignalSupport)
 
 /// Returns a signal that sends the receiver when its gesture occurs.
 - (RACSignal<__kindof UIGestureRecognizer *> *)rac_gestureSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIImagePickerController+RACSignalSupport.h
+++ b/ReactiveObjC/UIImagePickerController+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACDelegateProxy;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIImagePickerController (RACSignalSupport)
 
 /// A delegate proxy which will be set as the receiver's delegate when any of the
@@ -31,3 +33,5 @@
 - (RACSignal<NSDictionary *> *)rac_imageSelectedSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIRefreshControl+RACCommandSupport.h
+++ b/ReactiveObjC/UIRefreshControl+RACCommandSupport.h
@@ -10,6 +10,8 @@
 
 @class RACCommand<__contravariant InputType, __covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIRefreshControl (RACCommandSupport)
 
 /// Manipulate the RACCommand property associated with this refresh control.
@@ -17,6 +19,8 @@
 /// When this refresh control is activated by the user, the command will be
 /// executed. Upon completion or error of the execution signal, -endRefreshing
 /// will be invoked.
-@property (nonatomic, strong) RACCommand<__kindof UIRefreshControl *, id> *rac_command;
+@property (nonatomic, strong, nullable) RACCommand<__kindof UIRefreshControl *, id> *rac_command;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
+++ b/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISegmentedControl (RACSignalSupport)
 
 /// Creates a new RACChannel-based binding to the receiver.
@@ -19,6 +21,8 @@
 /// Returns a RACChannelTerminal that sends the receiver's currently selected
 /// segment's index whenever the UIControlEventValueChanged control event is
 /// fired, and sets the selected segment index to the values it receives.
-- (RACChannelTerminal *)rac_newSelectedSegmentIndexChannelWithNilValue:(NSNumber *)nilValue;
+- (RACChannelTerminal *)rac_newSelectedSegmentIndexChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UISlider+RACSignalSupport.h
+++ b/ReactiveObjC/UISlider+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISlider (RACSignalSupport)
 
 /// Creates a new RACChannel-based binding to the receiver.
@@ -19,6 +21,8 @@
 /// Returns a RACChannelTerminal that sends the receiver's value whenever the
 /// UIControlEventValueChanged control event is fired, and sets the value to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(NSNumber *)nilValue;
+- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIStepper+RACSignalSupport.h
+++ b/ReactiveObjC/UIStepper+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIStepper (RACSignalSupport)
 
 /// Creates a new RACChannel-based binding to the receiver.
@@ -19,6 +21,8 @@
 /// Returns a RACChannelTerminal that sends the receiver's value whenever the
 /// UIControlEventValueChanged control event is fired, and sets the value to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(NSNumber *)nilValue;
+- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UISwitch+RACSignalSupport.h
+++ b/ReactiveObjC/UISwitch+RACSignalSupport.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UISwitch (RACSignalSupport)
 
 /// Creates a new RACChannel-based binding to the receiver.
@@ -20,3 +22,5 @@
 - (RACChannelTerminal *)rac_newOnChannel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UITableViewCell+RACSignalSupport.h
+++ b/ReactiveObjC/UITableViewCell+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACSignal<__covariant ValueType>;
 @class RACUnit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UITableViewCell (RACSignalSupport)
 
 /// A signal which will send a RACUnit whenever -prepareForReuse is invoked upon
@@ -27,3 +29,5 @@
 @property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UITableViewHeaderFooterView+RACSignalSupport.h
+++ b/ReactiveObjC/UITableViewHeaderFooterView+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACSignal<__covariant ValueType>;
 @class RACUnit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // This category is only applicable to iOS >= 6.0.
 @interface UITableViewHeaderFooterView (RACSignalSupport)
 
@@ -28,3 +30,5 @@
 @property (nonatomic, strong, readonly) RACSignal<RACUnit *> *rac_prepareForReuseSignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UITextField+RACSignalSupport.h
+++ b/ReactiveObjC/UITextField+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACChannelTerminal;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UITextField (RACSignalSupport)
 
 /// Creates and returns a signal for the text of the field. It always starts with
@@ -26,3 +28,5 @@
 - (RACChannelTerminal *)rac_newTextChannel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UITextView+RACSignalSupport.h
+++ b/ReactiveObjC/UITextView+RACSignalSupport.h
@@ -35,10 +35,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-@interface UITextView (RACSignalSupportUnavailable)
-
-- (RACSignal *)rac_signalForDelegateMethod:(SEL)method __attribute__((unavailable("Use -rac_signalForSelector:fromProtocol: instead")));
-
-@end
-

--- a/ReactiveObjC/UITextView+RACSignalSupport.h
+++ b/ReactiveObjC/UITextView+RACSignalSupport.h
@@ -11,6 +11,8 @@
 @class RACDelegateProxy;
 @class RACSignal<__covariant ValueType>;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UITextView (RACSignalSupport)
 
 /// A delegate proxy which will be set as the receiver's delegate when any of the
@@ -32,8 +34,11 @@
 
 @end
 
+NS_ASSUME_NONNULL_END
+
 @interface UITextView (RACSignalSupportUnavailable)
 
 - (RACSignal *)rac_signalForDelegateMethod:(SEL)method __attribute__((unavailable("Use -rac_signalForSelector:fromProtocol: instead")));
 
 @end
+


### PR DESCRIPTION
Alongside lightweight generics, nullability annotations are a hallmark of a well-maintained and Swift-compatible Obj-C library.

Also:
- Improves the ability of the compiler to check against invalid API usage in Obj-C
- Removes unnecessary nil checks in initializers