### PR TITLE
Use instancetype in place of id and explicit return types

### DIFF
--- a/ReactiveObjC/NSObject+RACAppKitBindings.m
+++ b/ReactiveObjC/NSObject+RACAppKitBindings.m
@@ -50,7 +50,7 @@
 // options     - Any options to pass to the binding. This may be nil.
 //
 // Returns an initialized channel proxy.
-- (id)initWithTarget:(id)target bindingName:(NSString *)bindingName options:(NSDictionary *)options;
+- (instancetype)initWithTarget:(id)target bindingName:(NSString *)bindingName options:(NSDictionary *)options;
 
 @end
 
@@ -81,7 +81,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithTarget:(id)target bindingName:(NSString *)bindingName options:(NSDictionary *)options {
+- (instancetype)initWithTarget:(id)target bindingName:(NSString *)bindingName options:(NSDictionary *)options {
 	NSCParameterAssert(target != nil);
 	NSCParameterAssert(bindingName != nil);
 

--- a/ReactiveObjC/RACArraySequence.m
+++ b/ReactiveObjC/RACArraySequence.m
@@ -101,7 +101,7 @@
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
 	self = [super initWithCoder:coder];
 	if (self == nil) return nil;
 

--- a/ReactiveObjC/RACBlockTrampoline.m
+++ b/ReactiveObjC/RACBlockTrampoline.m
@@ -17,7 +17,7 @@
 
 #pragma mark API
 
-- (id)initWithBlock:(id)block {
+- (instancetype)initWithBlock:(id)block {
 	self = [super init];
 
 	_block = [block copy];

--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Do not instantiate this class directly. Create a RACChannel instead.
 @interface RACChannelTerminal : RACSignal <RACSubscriber>
 
-- (id)init __attribute__((unavailable("Instantiate a RACChannel instead")));
+- (instancetype)init __attribute__((unavailable("Instantiate a RACChannel instead")));
 
 @end
 

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -19,13 +19,13 @@
 // A subscriber will will send values to the other terminal.
 @property (nonatomic, strong, readonly) id<RACSubscriber> otherTerminal;
 
-- (id)initWithValues:(RACSignal *)values otherTerminal:(id<RACSubscriber>)otherTerminal;
+- (instancetype)initWithValues:(RACSignal *)values otherTerminal:(id<RACSubscriber>)otherTerminal;
 
 @end
 
 @implementation RACChannel
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 
 	// We don't want any starting value from the leadingSubject, but we do want
@@ -49,7 +49,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithValues:(RACSignal *)values otherTerminal:(id<RACSubscriber>)otherTerminal {
+- (instancetype)initWithValues:(RACSignal *)values otherTerminal:(id<RACSubscriber>)otherTerminal {
 	NSCParameterAssert(values != nil);
 	NSCParameterAssert(otherTerminal != nil);
 

--- a/ReactiveObjC/RACCommand.m
+++ b/ReactiveObjC/RACCommand.m
@@ -65,12 +65,12 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 
 #pragma mark Lifecycle
 
-- (id)init {
+- (instancetype)init {
 	NSCAssert(NO, @"Use -initWithSignalBlock: instead");
 	return nil;
 }
 
-- (id)initWithSignalBlock:(RACSignal<id> * (^)(id input))signalBlock {
+- (instancetype)initWithSignalBlock:(RACSignal<id> * (^)(id input))signalBlock {
 	return [self initWithEnabled:nil signalBlock:signalBlock];
 }
 
@@ -79,7 +79,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	[_allowsConcurrentExecutionSubject sendCompleted];
 }
 
-- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal<id> * (^)(id input))signalBlock {
+- (instancetype)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal<id> * (^)(id input))signalBlock {
 	NSCParameterAssert(signalBlock != nil);
 
 	self = [super init];

--- a/ReactiveObjC/RACDisposable.m
+++ b/ReactiveObjC/RACDisposable.m
@@ -31,7 +31,7 @@
 
 #pragma mark Lifecycle
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 
 	_disposeBlock = (__bridge void *)self;
@@ -40,7 +40,7 @@
 	return self;
 }
 
-- (id)initWithBlock:(void (^)(void))block {
+- (instancetype)initWithBlock:(void (^)(void))block {
 	NSCParameterAssert(block != nil);
 
 	self = [super init];

--- a/ReactiveObjC/RACEmptySequence.m
+++ b/ReactiveObjC/RACEmptySequence.m
@@ -44,7 +44,7 @@
 	return self.class;
 }
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
 	// Return the singleton.
 	return self.class.empty;
 }

--- a/ReactiveObjC/RACEvent.m
+++ b/ReactiveObjC/RACEvent.m
@@ -15,7 +15,7 @@
 @property (nonatomic, strong, readonly) id object;
 
 // Initializes the receiver with the given type and object.
-- (id)initWithEventType:(RACEventType)type object:(id)object;
+- (instancetype)initWithEventType:(RACEventType)type object:(id)object;
 
 @end
 
@@ -56,7 +56,7 @@
 	return [[self alloc] initWithEventType:RACEventTypeNext object:value];
 }
 
-- (id)initWithEventType:(RACEventType)type object:(id)object {
+- (instancetype)initWithEventType:(RACEventType)type object:(id)object {
 	self = [super init];
 
 	_eventType = type;

--- a/ReactiveObjC/RACImmediateScheduler.m
+++ b/ReactiveObjC/RACImmediateScheduler.m
@@ -13,7 +13,7 @@
 
 #pragma mark Lifecycle
 
-- (id)init {
+- (instancetype)init {
 	return [super initWithName:@"org.reactivecocoa.ReactiveObjC.RACScheduler.immediateScheduler"];
 }
 

--- a/ReactiveObjC/RACKVOChannel.h
+++ b/ReactiveObjC/RACKVOChannel.h
@@ -85,13 +85,13 @@ NS_ASSUME_NONNULL_BEGIN
 ///            exception if `nil` is received (which might occur if an intermediate
 ///            object is set to `nil`).
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
-- (id)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
+- (instancetype)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
 #else
 // Swift builds with OS_OBJECT_HAVE_OBJC_SUPPORT=0 for Playgrounds and LLDB :(
-- (id)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
+- (instancetype)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
 #endif
 
-- (id)init __attribute__((unavailable("Use -initWithTarget:keyPath:nilValue: instead")));
+- (instancetype)init __attribute__((unavailable("Use -initWithTarget:keyPath:nilValue: instead")));
 
 @end
 

--- a/ReactiveObjC/RACKVOChannel.m
+++ b/ReactiveObjC/RACKVOChannel.m
@@ -69,7 +69,7 @@ static NSString * const RACKVOChannelDataDictionaryKey = @"RACKVOChannelKey";
 
 #pragma mark Lifecycle
 
-- (id)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(id)nilValue {
+- (instancetype)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(id)nilValue {
 	NSCParameterAssert(keyPath.rac_keyPathComponents.count > 0);
 
 	NSObject *strongTarget = target;

--- a/ReactiveObjC/RACKVOTrampoline.h
+++ b/ReactiveObjC/RACKVOTrampoline.h
@@ -26,6 +26,6 @@
 //            Cannot be nil.
 //
 // Returns the initialized object.
-- (id)initWithTarget:(__weak NSObject *)target observer:(__weak NSObject *)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block;
+- (instancetype)initWithTarget:(__weak NSObject *)target observer:(__weak NSObject *)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block;
 
 @end

--- a/ReactiveObjC/RACKVOTrampoline.m
+++ b/ReactiveObjC/RACKVOTrampoline.m
@@ -29,7 +29,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithTarget:(__weak NSObject *)target observer:(__weak NSObject *)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block {
+- (instancetype)initWithTarget:(__weak NSObject *)target observer:(__weak NSObject *)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block {
 	NSCParameterAssert(keyPath != nil);
 	NSCParameterAssert(block != nil);
 

--- a/ReactiveObjC/RACMulticastConnection+Private.h
+++ b/ReactiveObjC/RACMulticastConnection+Private.h
@@ -12,6 +12,6 @@
 
 @interface RACMulticastConnection ()
 
-- (id)initWithSourceSignal:(RACSignal *)source subject:(RACSubject *)subject;
+- (instancetype)initWithSourceSignal:(RACSignal *)source subject:(RACSubject *)subject;
 
 @end

--- a/ReactiveObjC/RACMulticastConnection.m
+++ b/ReactiveObjC/RACMulticastConnection.m
@@ -35,7 +35,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithSourceSignal:(RACSignal *)source subject:(RACSubject *)subject {
+- (instancetype)initWithSourceSignal:(RACSignal *)source subject:(RACSubject *)subject {
 	NSCParameterAssert(source != nil);
 	NSCParameterAssert(subject != nil);
 

--- a/ReactiveObjC/RACQueueScheduler+Subclass.h
+++ b/ReactiveObjC/RACQueueScheduler+Subclass.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///         This argument must not be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithName:(nullable NSString *)name queue:(dispatch_queue_t)queue;
+- (instancetype)initWithName:(nullable NSString *)name queue:(dispatch_queue_t)queue;
 
 /// Converts a date into a GCD time using dispatch_walltime().
 ///

--- a/ReactiveObjC/RACQueueScheduler.m
+++ b/ReactiveObjC/RACQueueScheduler.m
@@ -15,7 +15,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithName:(NSString *)name queue:(dispatch_queue_t)queue {
+- (instancetype)initWithName:(NSString *)name queue:(dispatch_queue_t)queue {
 	NSCParameterAssert(queue != NULL);
 
 	self = [super initWithName:name];

--- a/ReactiveObjC/RACScheduler+Private.h
+++ b/ReactiveObjC/RACScheduler+Private.h
@@ -31,7 +31,7 @@ extern NSString * const RACSchedulerCurrentSchedulerKey;
 // name - The name of the scheduler. If nil, a default name will be used.
 //
 // Returns the initialized object.
-- (id)initWithName:(nullable NSString *)name;
+- (instancetype)initWithName:(nullable NSString *)name;
 
 @end
 

--- a/ReactiveObjC/RACScheduler.m
+++ b/ReactiveObjC/RACScheduler.m
@@ -31,7 +31,7 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 
 #pragma mark Initializers
 
-- (id)initWithName:(NSString *)name {
+- (instancetype)initWithName:(NSString *)name {
 	self = [super init];
 
 	if (name == nil) {
@@ -45,7 +45,7 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 
 #pragma mark Schedulers
 
-+ (instancetype)immediateScheduler {
++ (RACScheduler *)immediateScheduler {
 	static dispatch_once_t onceToken;
 	static RACScheduler *immediateScheduler;
 	dispatch_once(&onceToken, ^{
@@ -55,7 +55,7 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 	return immediateScheduler;
 }
 
-+ (instancetype)mainThreadScheduler {
++ (RACScheduler *)mainThreadScheduler {
 	static dispatch_once_t onceToken;
 	static RACScheduler *mainThreadScheduler;
 	dispatch_once(&onceToken, ^{
@@ -65,19 +65,19 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 	return mainThreadScheduler;
 }
 
-+ (instancetype)schedulerWithPriority:(RACSchedulerPriority)priority name:(NSString *)name {
++ (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority name:(NSString *)name {
 	return [[RACTargetQueueScheduler alloc] initWithName:name targetQueue:dispatch_get_global_queue(priority, 0)];
 }
 
-+ (instancetype)schedulerWithPriority:(RACSchedulerPriority)priority {
++ (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority {
 	return [self schedulerWithPriority:priority name:@"org.reactivecocoa.ReactiveObjC.RACScheduler.backgroundScheduler"];
 }
 
-+ (instancetype)scheduler {
++ (RACScheduler *)scheduler {
 	return [self schedulerWithPriority:RACSchedulerPriorityDefault];
 }
 
-+ (instancetype)subscriptionScheduler {
++ (RACScheduler *)subscriptionScheduler {
 	static dispatch_once_t onceToken;
 	static RACScheduler *subscriptionScheduler;
 	dispatch_once(&onceToken, ^{
@@ -91,7 +91,7 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 	return [NSOperationQueue.currentQueue isEqual:NSOperationQueue.mainQueue] || [NSThread isMainThread];
 }
 
-+ (instancetype)currentScheduler {
++ (RACScheduler *)currentScheduler {
 	RACScheduler *scheduler = NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey];
 	if (scheduler != nil) return scheduler;
 	if ([self.class isOnMainThread]) return RACScheduler.mainThreadScheduler;

--- a/ReactiveObjC/RACStream.m
+++ b/ReactiveObjC/RACStream.m
@@ -15,7 +15,7 @@
 
 #pragma mark Lifecycle
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 
 	self.name = @"";

--- a/ReactiveObjC/RACSubject.m
+++ b/ReactiveObjC/RACSubject.m
@@ -35,7 +35,7 @@
 	return [[self alloc] init];
 }
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 	if (self == nil) return nil;
 

--- a/ReactiveObjC/RACSubscriber.m
+++ b/ReactiveObjC/RACSubscriber.m
@@ -36,7 +36,7 @@
 	return subscriber;
 }
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 
 	@unsafeify(self);

--- a/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveObjC/RACSubscriptingAssignmentTrampoline.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RACSubscriptingAssignmentTrampoline : NSObject
 
-- (nullable id)initWithTarget:(nullable id)target nilValue:(nullable id)nilValue;
+- (nullable instancetype)initWithTarget:(nullable id)target nilValue:(nullable id)nilValue;
 - (void)setObject:(RACSignal *)signal forKeyedSubscript:(NSString *)keyPath;
 
 @end

--- a/ReactiveObjC/RACSubscriptingAssignmentTrampoline.m
+++ b/ReactiveObjC/RACSubscriptingAssignmentTrampoline.m
@@ -21,7 +21,7 @@
 
 @implementation RACSubscriptingAssignmentTrampoline
 
-- (id)initWithTarget:(id)target nilValue:(id)nilValue {
+- (instancetype)initWithTarget:(id)target nilValue:(id)nilValue {
 	// This is often a programmer error, but this prevents crashes if the target
 	// object has unexpectedly deallocated.
 	if (target == nil) return nil;

--- a/ReactiveObjC/RACSubscriptionScheduler.m
+++ b/ReactiveObjC/RACSubscriptionScheduler.m
@@ -21,7 +21,7 @@
 
 #pragma mark Lifecycle
 
-- (id)init {
+- (instancetype)init {
 	self = [super initWithName:@"org.reactivecocoa.ReactiveObjC.RACScheduler.subscriptionScheduler"];
 
 	_backgroundScheduler = [RACScheduler scheduler];

--- a/ReactiveObjC/RACTargetQueueScheduler.h
+++ b/ReactiveObjC/RACTargetQueueScheduler.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// targetQueue - The queue to target. Cannot be NULL.
 ///
 /// Returns the initialized object.
-- (id)initWithName:(nullable NSString *)name targetQueue:(dispatch_queue_t)targetQueue;
+- (instancetype)initWithName:(nullable NSString *)name targetQueue:(dispatch_queue_t)targetQueue;
 
 @end
 

--- a/ReactiveObjC/RACTargetQueueScheduler.m
+++ b/ReactiveObjC/RACTargetQueueScheduler.m
@@ -13,7 +13,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithName:(NSString *)name targetQueue:(dispatch_queue_t)targetQueue {
+- (instancetype)initWithName:(NSString *)name targetQueue:(dispatch_queue_t)targetQueue {
 	NSCParameterAssert(targetQueue != NULL);
 
 	if (name == nil) {

--- a/ReactiveObjC/RACTestScheduler.m
+++ b/ReactiveObjC/RACTestScheduler.m
@@ -29,7 +29,7 @@
 @property (nonatomic, strong, readonly) RACDisposable *disposable;
 
 // Initializes a new scheduler action.
-- (id)initWithDate:(NSDate *)date block:(void (^)(void))block;
+- (instancetype)initWithDate:(NSDate *)date block:(void (^)(void))block;
 
 @end
 
@@ -199,7 +199,7 @@ static void RACReleaseScheduledAction(CFAllocatorRef allocator, const void *ptr)
 
 #pragma mark Lifecycle
 
-- (id)initWithDate:(NSDate *)date block:(void (^)(void))block {
+- (instancetype)initWithDate:(NSDate *)date block:(void (^)(void))block {
 	NSCParameterAssert(date != nil);
 	NSCParameterAssert(block != nil);
 

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -30,7 +30,7 @@
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
 	// Always return the singleton.
 	return self.class.tupleNil;
 }
@@ -89,7 +89,7 @@
 
 #pragma mark NSCoding
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
 	self = [self init];
 	
 	self.backingArray = [coder decodeObjectForKey:@keypath(self.backingArray)];

--- a/ReactiveObjC/RACUnarySequence.m
+++ b/ReactiveObjC/RACUnarySequence.m
@@ -52,7 +52,7 @@
 	return self.class;
 }
 
-- (id)initWithCoder:(NSCoder *)coder {
+- (instancetype)initWithCoder:(NSCoder *)coder {
 	id value = [coder decodeObjectForKey:@keypath(self.head)];
 	return [self.class return:value];
 }

--- a/ReactiveObjCTests/RACTestExampleScheduler.h
+++ b/ReactiveObjCTests/RACTestExampleScheduler.h
@@ -10,6 +10,6 @@
 
 @interface RACTestExampleScheduler : RACQueueScheduler
 
-- (id)initWithQueue:(dispatch_queue_t)queue;
+- (instancetype)initWithQueue:(dispatch_queue_t)queue;
 
 @end

--- a/ReactiveObjCTests/RACTestExampleScheduler.m
+++ b/ReactiveObjCTests/RACTestExampleScheduler.m
@@ -13,7 +13,7 @@
 
 #pragma mark Lifecycle
 
-- (id)initWithQueue:(dispatch_queue_t)queue {
+- (instancetype)initWithQueue:(dispatch_queue_t)queue {
 	return [super initWithName:nil queue:queue];
 }
 


### PR DESCRIPTION
The compiler is better able to infer the types of these via an instancetype declaration than with the existing id or explicit return types. As far as I can tell, this will not affect Obj-C usage in practice, but can affect consumption in Swift (more in an forthcoming diff in the bridging repository).