### PR TITLE
Add lightweight generics to signal operations where applicable

### DIFF
--- a/ReactiveObjC/RACCommand.h
+++ b/ReactiveObjC/RACCommand.h
@@ -79,7 +79,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 @property (atomic, assign) BOOL allowsConcurrentExecution;
 
 /// Invokes -initWithEnabled:signalBlock: with a nil `enabledSignal`.
-- (id)initWithSignalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
+- (instancetype)initWithSignalBlock:(RACSignal<ValueType> * (^)(InputType _Nullable input))signalBlock;
 
 /// Initializes a command that is conditionally enabled.
 ///
@@ -94,7 +94,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///                 to a replay subject, sent on `executionSignals`, then
 ///                 subscribed to synchronously. Neither the block nor the
 ///                 returned signal may be nil.
-- (id)initWithEnabled:(nullable RACSignal<NSNumber *> *)enabledSignal signalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
+- (instancetype)initWithEnabled:(nullable RACSignal<NSNumber *> *)enabledSignal signalBlock:(RACSignal<ValueType> * (^)(InputType _Nullable input))signalBlock;
 
 /// If the receiver is enabled, this method will:
 ///

--- a/ReactiveObjC/RACCommand.m
+++ b/ReactiveObjC/RACCommand.m
@@ -70,7 +70,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	return nil;
 }
 
-- (id)initWithSignalBlock:(RACSignal * (^)(id input))signalBlock {
+- (id)initWithSignalBlock:(RACSignal<id> * (^)(id input))signalBlock {
 	return [self initWithEnabled:nil signalBlock:signalBlock];
 }
 
@@ -79,7 +79,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	[_allowsConcurrentExecutionSubject sendCompleted];
 }
 
-- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(id input))signalBlock {
+- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal<id> * (^)(id input))signalBlock {
 	NSCParameterAssert(signalBlock != nil);
 
 	self = [super init];

--- a/ReactiveObjC/RACEvent.h
+++ b/ReactiveObjC/RACEvent.h
@@ -24,16 +24,16 @@ typedef NS_ENUM(NSUInteger, RACEventType) {
 /// Represents an event sent by a RACSignal.
 ///
 /// This corresponds to the `Notification` class in Rx.
-@interface RACEvent : NSObject <NSCopying>
+@interface RACEvent<__covariant ValueType> : NSObject <NSCopying>
 
 /// Returns a singleton RACEvent representing the `completed` event.
-+ (instancetype)completedEvent;
++ (RACEvent<ValueType> *)completedEvent;
 
 /// Returns a new event of type RACEventTypeError, containing the given error.
-+ (instancetype)eventWithError:(nullable NSError *)error;
++ (RACEvent<ValueType> *)eventWithError:(nullable NSError *)error;
 
 /// Returns a new event of type RACEventTypeNext, containing the given value.
-+ (instancetype)eventWithValue:(nullable id)value;
++ (RACEvent<ValueType> *)eventWithValue:(nullable ValueType)value;
 
 /// The type of event represented by the receiver.
 @property (nonatomic, assign, readonly) RACEventType eventType;
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, RACEventType) {
 
 /// The value associated with an event of type RACEventTypeNext. This will be
 /// nil for all other event types.
-@property (nonatomic, strong, readonly, nullable) id value;
+@property (nonatomic, strong, readonly, nullable) ValueType value;
 
 @end
 

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -16,6 +16,7 @@
 @class RACSequence;
 @class RACSubject;
 @class RACTuple;
+@class RACEvent<__covariant ValueType>;
 @protocol RACSubscriber;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -30,19 +31,19 @@ extern const NSInteger RACSignalErrorTimedOut;
 /// match any of the cases, and no default was given.
 extern const NSInteger RACSignalErrorNoMatchingCase;
 
-@interface RACSignal (Operations)
+@interface RACSignal<__covariant ValueType> (Operations)
 
 /// Do the given block on `next`. This should be used to inject side effects into
 /// the signal.
-- (RACSignal *)doNext:(void (^)(id _Nullable x))block;
+- (RACSignal<ValueType> *)doNext:(void (^)(ValueType _Nullable x))block;
 
 /// Do the given block on `error`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal *)doError:(void (^)(NSError * _Nonnull error))block;
+- (RACSignal<ValueType> *)doError:(void (^)(NSError * _Nonnull error))block;
 
 /// Do the given block on `completed`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal *)doCompleted:(void (^)(void))block;
+- (RACSignal<ValueType> *)doCompleted:(void (^)(void))block;
 
 /// Sends `next`s only if we don't receive another `next` in `interval` seconds.
 ///
@@ -56,7 +57,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends throttled and delayed `next` events. Completion
 /// and errors are always forwarded immediately.
-- (RACSignal *)throttle:(NSTimeInterval)interval;
+- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval;
 
 /// Throttles `next`s for which `predicate` returns YES.
 ///
@@ -81,7 +82,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends `next` events, throttled when `predicate`
 /// returns YES. Completion and errors are always forwarded immediately.
-- (RACSignal *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id _Nullable next))predicate;
+- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id _Nullable next))predicate;
 
 /// Forwards `next` and `completed` events after delaying for `interval` seconds
 /// on the current scheduler (on which the events were delivered).
@@ -91,10 +92,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends delayed `next` and `completed` events. Errors
 /// are always forwarded immediately.
-- (RACSignal *)delay:(NSTimeInterval)interval;
+- (RACSignal<ValueType> *)delay:(NSTimeInterval)interval;
 
 /// Resubscribes when the signal completes.
-- (RACSignal *)repeat;
+- (RACSignal<ValueType> *)repeat;
 
 /// Executes the given block each time a subscription is created.
 ///
@@ -120,10 +121,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that passes through all events of the receiver, plus
 /// introduces side effects which occur prior to any subscription side effects
 /// of the receiver.
-- (RACSignal *)initially:(void (^)(void))block;
+- (RACSignal<ValueType> *)initially:(void (^)(void))block;
 
 /// Executes the given block when the signal completes or errors.
-- (RACSignal *)finally:(void (^)(void))block;
+- (RACSignal<ValueType> *)finally:(void (^)(void))block;
 
 /// Divides the receiver's `next`s into buffers which deliver every `interval`
 /// seconds.
@@ -136,7 +137,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which sends RACTuples of the buffered values at each
 /// interval on `scheduler`. When the receiver completes, any currently-buffered
 /// values will be sent immediately.
-- (RACSignal *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
 /// Collects all receiver's `next`s into a NSArray. Nil values will be converted
 /// to NSNull.
@@ -145,10 +146,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends a single NSArray when the receiver completes
 /// successfully.
-- (RACSignal *)collect;
+- (RACSignal<NSArray<ValueType> *> *)collect;
 
 /// Takes the last `count` `next`s after the receiving signal completes.
-- (RACSignal *)takeLast:(NSUInteger)count;
+- (RACSignal<ValueType> *)takeLast:(NSUInteger)count;
 
 /// Combines the latest values from the receiver and the given signal into
 /// RACTuples, once both have sent at least one `next`.
@@ -173,7 +174,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends RACTuples of the combined values, forwards any
 /// `error` events, and completes when all input signals complete.
-+ (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals;
++ (RACSignal<ValueType> *)combineLatest:(id<NSFastEnumeration>)signals;
 
 /// Combines signals using +combineLatest:, then reduces the resulting tuples
 /// into a single value using -reduceEach:.
@@ -194,7 +195,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends the results from each invocation of
 /// `reduceBlock`.
-+ (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals reduce:(id (^)())reduceBlock;
++ (RACSignal<ValueType> *)combineLatest:(id<NSFastEnumeration>)signals reduce:(ValueType _Nullable (^)())reduceBlock;
 
 /// Merges the receiver and the given signal with `+merge:` and returns the
 /// resulting signal.
@@ -205,7 +206,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that passes through values from each of the given signals,
 /// and sends `completed` when all of them complete. If any signal sends an error,
 /// the returned signal sends `error` immediately.
-+ (RACSignal *)merge:(id<NSFastEnumeration>)signals;
++ (RACSignal<ValueType> *)merge:(id<NSFastEnumeration>)signals;
 
 /// Merges the signals sent by the receiver into a flattened signal, but only
 /// subscribes to `maxConcurrent` number of signals at a time. New signals are
@@ -338,7 +339,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal that sends the current date/time every `interval` on
 /// `scheduler`.
-+ (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
++ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
 /// Sends NSDate.date at intervals of at least `interval` seconds, up to
 /// approximately `interval` + `leeway` seconds.
@@ -356,14 +357,14 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that sends the current date/time at intervals of at least
 /// `interval seconds` up to approximately `interval` + `leeway` seconds on
 /// `scheduler`.
-+ (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway;
++ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway;
 
 /// Takes `next`s until the `signalTrigger` sends `next` or `completed`.
 ///
 /// Returns a signal which passes through all events from the receiver until
 /// `signalTrigger` sends `next` or `completed`, at which point the returned signal
 /// will send `completed`.
-- (RACSignal *)takeUntil:(RACSignal *)signalTrigger;
+- (RACSignal<ValueType> *)takeUntil:(RACSignal *)signalTrigger;
 
 /// Takes `next`s until the `replacement` sends an event.
 ///
@@ -395,7 +396,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///   [RACSignal try:^(NSError **error) {
 ///       return [NSJSONSerialization JSONObjectWithData:someJSONData options:0 error:error];
 ///   }];
-+ (RACSignal *)try:(id (^)(NSError **errorPtr))tryBlock;
++ (RACSignal<ValueType> *)try:(nullable ValueType (^)(NSError **errorPtr))tryBlock;
 
 /// Runs `tryBlock` against each of the receiver's values, passing values
 /// until `tryBlock` returns NO, or the receiver completes.
@@ -438,18 +439,18 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal *)tryMap:(id (^)(id _Nullable value, NSError **errorPtr))mapBlock;
 
 /// Returns the first `next`. Note that this is a blocking call.
-- (nullable id)first;
+- (nullable ValueType)first;
 
 /// Returns the first `next` or `defaultValue` if the signal completes or errors
 /// without sending a `next`. Note that this is a blocking call.
-- (nullable id)firstOrDefault:(nullable id)defaultValue;
+- (nullable ValueType)firstOrDefault:(nullable ValueType)defaultValue;
 
 /// Returns the first `next` or `defaultValue` if the signal completes or errors
 /// without sending a `next`. If an error occurs success will be NO and error
 /// will be populated. Note that this is a blocking call.
 ///
 /// Both success and error may be NULL.
-- (nullable id)firstOrDefault:(nullable id)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
+- (nullable ValueType)firstOrDefault:(nullable ValueType)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
 
 /// Blocks the caller and waits for the signal to complete.
 ///
@@ -462,7 +463,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Defers creation of a signal until the signal's actually subscribed to.
 ///
 /// This can be used to effectively turn a hot signal into a cold signal.
-+ (RACSignal *)defer:(RACSignal * (^)(void))block;
++ (RACSignal<ValueType> *)defer:(RACSignal<ValueType> * (^)(void))block;
 
 /// Every time the receiver sends a new RACSignal, subscribes and sends `next`s and
 /// `error`s only for that signal.
@@ -491,7 +492,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// the signals in `cases` or `defaultSignal`, and sends `completed` when both
 /// `signal` and the last used signal complete. If no `defaultSignal` is given,
 /// an unmatched `next` will result in an error on the returned signal.
-+ (RACSignal *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(nullable RACSignal *)defaultSignal;
++ (RACSignal<ValueType> *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(nullable RACSignal *)defaultSignal;
 
 /// Switches between `trueSignal` and `falseSignal` based on the latest value
 /// sent by `boolSignal`.
@@ -506,7 +507,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which passes through `next`s and `error`s from `trueSignal`
 /// and/or `falseSignal`, and sends `completed` when both `boolSignal` and the
 /// last switched signal complete.
-+ (RACSignal *)if:(RACSignal *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal;
++ (RACSignal<ValueType> *)if:(RACSignal *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal;
 
 /// Adds every `next` to an array. Nils are represented by NSNulls. Note that
 /// this is a blocking call.
@@ -515,7 +516,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// that behavior instead.
 ///
 /// Returns the array of `next` values, or nil if an error occurs.
-- (nullable NSArray *)toArray;
+- (nullable NSArray<ValueType> *)toArray;
 
 /// Adds every `next` to a sequence. Nils are represented by NSNulls.
 ///
@@ -539,13 +540,13 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// immediately connects to the resulting RACMulticastConnection.
 ///
 /// Returns the connected, multicasted signal.
-- (RACSignal *)replay;
+- (RACSignal<ValueType> *)replay;
 
 /// Multicasts the signal to a RACReplaySubject of capacity 1, and immediately
 /// connects to the resulting RACMulticastConnection.
 ///
 /// Returns the connected, multicasted signal.
-- (RACSignal *)replayLast;
+- (RACSignal<ValueType> *)replayLast;
 
 /// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
 /// lazily connects to the resulting RACMulticastConnection.
@@ -554,7 +555,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// when the former receives its first subscription.
 ///
 /// Returns the lazily connected, multicasted signal.
-- (RACSignal *)replayLazily;
+- (RACSignal<ValueType> *)replayLazily;
 
 /// Sends an error after `interval` seconds if the source doesn't complete
 /// before then.
@@ -568,7 +569,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal that passes through the receiver's events, until the stream
 /// finishes or times out, at which point an error will be sent on `scheduler`.
-- (RACSignal *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
 /// Creates and returns a signal that delivers its events on the given scheduler.
 /// Any side effects of the receiver will still be performed on the original
@@ -578,7 +579,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// thread, but you want to handle its events elsewhere.
 ///
 /// This corresponds to the `ObserveOn` method in Rx.
-- (RACSignal *)deliverOn:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)deliverOn:(RACScheduler *)scheduler;
 
 /// Creates and returns a signal that executes its side effects and delivers its
 /// events on the given scheduler.
@@ -586,7 +587,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Use of this operator should be avoided whenever possible, because the
 /// receiver's side effects may not be safe to run on another thread. If you just
 /// want to receive the signal's events on `scheduler`, use -deliverOn: instead.
-- (RACSignal *)subscribeOn:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)subscribeOn:(RACScheduler *)scheduler;
 
 /// Creates and returns a signal that delivers its events on the main thread.
 /// If events are already being sent on the main thread, they may be passed on
@@ -600,7 +601,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// This can be used when a signal will cause UI updates, to avoid potential
 /// flicker caused by delayed delivery of events, such as the first event from
 /// a RACObserve at view instantiation.
-- (RACSignal *)deliverOnMainThread;
+- (RACSignal<ValueType> *)deliverOnMainThread;
 
 /// Groups each received object into a group, as determined by calling `keyBlock`
 /// with that object. The object sent is transformed by calling `transformBlock`
@@ -614,28 +615,28 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
 /// objects.
-- (RACSignal *)any;
+- (RACSignal<NSNumber *> *)any;
 
 /// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
 /// objects that pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal *)any:(BOOL (^)(id _Nullable object))predicateBlock;
+- (RACSignal<NSNumber *> *)any:(BOOL (^)(id _Nullable object))predicateBlock;
 
 /// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
 /// signal sends pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal *)all:(BOOL (^)(id _Nullable object))predicateBlock;
+- (RACSignal<NSNumber *> *)all:(BOOL (^)(id _Nullable object))predicateBlock;
 
 /// Resubscribes to the receiving signal if an error occurs, up until it has
 /// retried the given number of times.
 ///
 /// retryCount - if 0, it keeps retrying until it completes.
-- (RACSignal *)retry:(NSInteger)retryCount;
+- (RACSignal<ValueType> *)retry:(NSInteger)retryCount;
 
 /// Resubscribes to the receiving signal if an error occurs.
-- (RACSignal *)retry;
+- (RACSignal<ValueType> *)retry;
 
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
@@ -644,19 +645,19 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// sampler - The signal that controls when the latest value from the receiver
 ///           is sent. Cannot be nil.
-- (RACSignal *)sample:(RACSignal *)sampler;
+- (RACSignal<ValueType> *)sample:(RACSignal *)sampler;
 
 /// Ignores all `next`s from the receiver.
 ///
 /// Returns a signal which only passes through `error` or `completed` events from
 /// the receiver.
-- (RACSignal *)ignoreValues;
+- (RACSignal<ValueType> *)ignoreValues;
 
 /// Converts each of the receiver's events into a RACEvent object.
 ///
 /// Returns a signal which sends the receiver's events as RACEvents, and
 /// completes after the receiver sends `completed` or `error`.
-- (RACSignal *)materialize;
+- (RACSignal<RACEvent<ValueType> *> *)materialize;
 
 /// Converts each RACEvent in the receiver back into "real" RACSignal events.
 ///
@@ -668,21 +669,21 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// the receiver sends anything other than NSNumbers.
 ///
 /// Returns a signal of inverted NSNumber-wrapped BOOLs.
-- (RACSignal *)not;
+- (RACSignal<NSNumber *> *)not;
 
 /// Performs a boolean AND on all of the RACTuple of NSNumbers in sent by the receiver.
 ///
 /// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
 ///
 /// Returns a signal that applies AND to each NSNumber in the tuple.
-- (RACSignal *)and;
+- (RACSignal<NSNumber *> *)and;
 
 /// Performs a boolean OR on all of the RACTuple of NSNumbers in sent by the receiver.
 ///
 /// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
 /// 
 /// Returns a signal that applies OR to each NSNumber in the tuple.
-- (RACSignal *)or;
+- (RACSignal<NSNumber *> *)or;
 
 /// Sends the result of calling the block with arguments as packed in each RACTuple
 /// sent by the receiver.

--- a/ReactiveObjC/RACSignal+Operations.m
+++ b/ReactiveObjC/RACSignal+Operations.m
@@ -931,7 +931,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 	return success;
 }
 
-+ (RACSignal *)defer:(RACSignal * (^)(void))block {
++ (RACSignal *)defer:(RACSignal<id> * (^)(void))block {
 	NSCParameterAssert(block != NULL);
 
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -46,13 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// subscribes. Any side effects within the block will thus execute once for each
 /// subscription, not necessarily on one thread, and possibly even
 /// simultaneously!
-+ (RACSignal *)createSignal:(RACDisposable * _Nullable (^)(id<RACSubscriber> subscriber))didSubscribe;
++ (RACSignal<ValueType> *)createSignal:(RACDisposable * _Nullable (^)(id<RACSubscriber> subscriber))didSubscribe;
 
 /// Returns a signal that immediately sends the given error.
-+ (RACSignal *)error:(nullable NSError *)error;
++ (RACSignal<ValueType> *)error:(nullable NSError *)error;
 
 /// Returns a signal that never completes.
-+ (RACSignal *)never;
++ (RACSignal<ValueType> *)never;
 
 /// Immediately schedules the given block on the given scheduler. The block is
 /// given a subscriber to which it can send events.
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a signal which will send all events sent on the subscriber given to
 /// `block`. All events will be sent on `scheduler` and it will replay any missed
 /// events to new subscribers.
-+ (RACSignal *)startEagerlyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
++ (RACSignal<ValueType> *)startEagerlyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
 
 /// Invokes the given block only on the first subscription. The block is given a
 /// subscriber to which it can send events.
@@ -82,17 +82,17 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns a signal which will pass through the events sent to the subscriber
 /// given to `block` and replay any missed events to new subscribers.
-+ (RACSignal *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
++ (RACSignal<ValueType> *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
 
 @end
 
-@interface RACSignal (RACStream)
+@interface RACSignal<__covariant ValueType> (RACStream)
 
 /// Returns a signal that immediately sends the given value and then completes.
-+ (RACSignal *)return:(nullable id)value;
++ (RACSignal<ValueType> *)return:(nullable ValueType)value;
 
 /// Returns a signal that immediately completes.
-+ (RACSignal *)empty;
++ (RACSignal<ValueType> *)empty;
 
 /// Subscribes to `signal` when the source signal completes.
 - (RACSignal *)concat:(RACSignal *)signal;
@@ -162,19 +162,19 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /// Additional methods to assist with debugging.
-@interface RACSignal (Debugging)
+@interface RACSignal<__covariant ValueType> (Debugging)
 
 /// Logs all events that the receiver sends.
-- (RACSignal *)logAll;
+- (RACSignal<ValueType> *)logAll;
 
 /// Logs each `next` that the receiver sends.
-- (RACSignal *)logNext;
+- (RACSignal<ValueType> *)logNext;
 
 /// Logs any error that the receiver sends.
-- (RACSignal *)logError;
+- (RACSignal<ValueType> *)logError;
 
 /// Logs any `completed` event that the receiver sends.
-- (RACSignal *)logCompleted;
+- (RACSignal<ValueType> *)logCompleted;
 
 @end
 


### PR DESCRIPTION
For many `RACSignal` operators, the `ValueType` of signals will not change due to operator being invoked. As such, in these cases, lightweight generics can be added to improve the type signature of the return value.

This additionally adds lightweight generics to `RACEvent` so that it can maintain the `ValueType` of the `RACSignal` events that is is representing via the `materialize` operator.

Finally, in some places (such as class methods on `RACSignal`, the return type has been updated to be `RACSignal<ValueType> *`. This is to allow the following style of declaration in Swift:

```
let signal = RACSignal<NSNumber>.createSignal { subscriber…
```

This follows the pattern of Apple’s generics, e.g. `+[NSArray (nullable NSMutableArray<ObjectType> *)arrayWithContentsOfFile:(NSString *)path]`