### PR TITLE
Fix static analyzer warnings

### DIFF
--- a/ReactiveObjC/RACStream.m
+++ b/ReactiveObjC/RACStream.m
@@ -25,23 +25,28 @@
 #pragma mark Abstract methods
 
 + (instancetype)empty {
-	return nil;
+	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
+	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
 - (instancetype)bind:(RACStreamBindBlock (^)(void))block {
-	return nil;
+	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
+	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
 + (instancetype)return:(id)value {
-	return nil;
+	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
+	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
 - (instancetype)concat:(RACStream *)stream {
-	return nil;
+	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
+	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
 - (instancetype)zipWith:(RACStream *)stream {
-	return nil;
+	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
+	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
 #pragma mark Naming


### PR DESCRIPTION
Fixes the warning emitted by the static analyzer:
> Null is returned from a method that is expected to return a non-null value

This change should not be an issue in practice because consumers should not be invoking methods on `RACStream` directly, as it is an abstract base class.