### PR TITLE
Update version to 2.1

### DIFF
--- a/ReactiveObjC.podspec
+++ b/ReactiveObjC.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ReactiveObjC"
-  s.version      = "2.0.0"
+  s.version      = "2.1.0"
   s.summary      = "The 2.x ReactiveCocoa Objective-C API: Streams of values over time"
 
   s.description  = <<-DESC.strip_heredoc

--- a/ReactiveObjC/Info.plist
+++ b/ReactiveObjC/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReactiveObjCTests/Info.plist
+++ b/ReactiveObjCTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This is to make a release that https://github.com/ReactiveCocoa/ReactiveObjCBridge/pull/6 will be able to consume.

I think it would make sense to merge ~#34~, ~#37~, ~#41~, and ~#42~ before making this release.