### PR TITLE
Redeclare operations built on RACStream primitives with more precise type information (continued)

### DIFF
--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -2874,10 +2874,6 @@
 			baseConfigurationReference = D047263219E49FE8006002AA /* iOS-Application.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = ReactiveObjCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
@@ -2889,10 +2885,6 @@
 			baseConfigurationReference = D047263219E49FE8006002AA /* iOS-Application.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = ReactiveObjCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
@@ -2967,10 +2959,6 @@
 			baseConfigurationReference = D047263219E49FE8006002AA /* iOS-Application.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = ReactiveObjCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
@@ -3045,10 +3033,6 @@
 			baseConfigurationReference = D047263219E49FE8006002AA /* iOS-Application.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = ReactiveObjCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";

--- a/ReactiveObjC/RACArraySequence.h
+++ b/ReactiveObjC/RACArraySequence.h
@@ -13,6 +13,6 @@
 
 // Returns a sequence for enumerating over the given array, starting from the
 // given offset. The array will be copied to prevent mutation.
-+ (instancetype)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset;
++ (RACSequence *)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveObjC/RACArraySequence.m
+++ b/ReactiveObjC/RACArraySequence.m
@@ -26,7 +26,7 @@
 
 #pragma mark Lifecycle
 
-+ (instancetype)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset {
++ (RACSequence *)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset {
 	NSCParameterAssert(offset <= array.count);
 
 	if (offset == array.count) return self.empty;

--- a/ReactiveObjC/RACEagerSequence.m
+++ b/ReactiveObjC/RACEagerSequence.m
@@ -14,11 +14,11 @@
 
 #pragma mark RACStream
 
-+ (instancetype)return:(id)value {
++ (RACSequence *)return:(id)value {
 	return [[self sequenceWithArray:@[ value ] offset:0] setNameWithFormat:@"+return: %@", RACDescription(value)];
 }
 
-- (instancetype)bind:(RACStreamBindBlock (^)(void))block {
+- (RACSequence *)bind:(RACSequenceBindBlock (^)(void))block {
 	NSCParameterAssert(block != nil);
 	RACStreamBindBlock bindBlock = block();
 	NSArray *currentArray = self.array;
@@ -39,7 +39,7 @@
 	return [[self.class sequenceWithArray:resultArray offset:0] setNameWithFormat:@"[%@] -bind:", self.name];
 }
 
-- (instancetype)concat:(RACSequence *)sequence {
+- (RACSequence *)concat:(RACSequence *)sequence {
 	NSCParameterAssert(sequence != nil);
 	NSCParameterAssert([sequence isKindOfClass:RACSequence.class]);
 

--- a/ReactiveObjC/RACEmptySequence.h
+++ b/ReactiveObjC/RACEmptySequence.h
@@ -11,4 +11,6 @@
 // Private class representing an empty sequence.
 @interface RACEmptySequence : RACSequence
 
++ (RACEmptySequence *)empty;
+
 @end

--- a/ReactiveObjC/RACIndexSetSequence.h
+++ b/ReactiveObjC/RACIndexSetSequence.h
@@ -11,6 +11,6 @@
 // Private class that adapts an array to the RACSequence interface.
 @interface RACIndexSetSequence : RACSequence
 
-+ (instancetype)sequenceWithIndexSet:(NSIndexSet *)indexSet;
++ (RACSequence *)sequenceWithIndexSet:(NSIndexSet *)indexSet;
 
 @end

--- a/ReactiveObjC/RACIndexSetSequence.m
+++ b/ReactiveObjC/RACIndexSetSequence.m
@@ -28,7 +28,7 @@
 
 #pragma mark Lifecycle
 
-+ (instancetype)sequenceWithIndexSet:(NSIndexSet *)indexSet {
++ (RACSequence *)sequenceWithIndexSet:(NSIndexSet *)indexSet {
 	NSUInteger count = indexSet.count;
 	
 	if (count == 0) return self.empty;

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -149,4 +149,270 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/// A block which accepts a value from a RACSequence and returns a new sequence.
+///
+/// Setting `stop` to `YES` will cause the bind to terminate after the returned
+/// value. Returning `nil` will result in immediate termination.
+typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL *stop);
+
+@interface RACSequence (RACStream)
+
+/// Returns a sequence that immediately sends the given value and then completes.
++ (RACSequence *)return:(nullable)value;
+
+/// Returns a sequence that immediately completes.
++ (RACSequence *)empty;
+
+/// Lazily binds a block to the values in the receiver.
+///
+/// This should only be used if you need to terminate the bind early, or close
+/// over some state. -flattenMap: is more appropriate for all other cases.
+///
+/// block - A block returning a RACSequenceBindBlock. This block will be invoked
+///         each time the bound sequence is re-evaluated. This block must not be
+///         nil or return nil.
+///
+/// Returns a new sequence which represents the combined result of all lazy
+/// applications of `block`.
+- (RACSequence *)bind:(RACSequenceBindBlock (^)(void))block;
+
+/// Subscribes to `sequence` when the source sequence completes.
+- (RACSequence *)concat:(RACSequence *)sequence;
+
+/// Zips the values in the receiver with those of the given sequence to create
+/// RACTuples.
+///
+/// The first `next` of each sequence will be combined, then the second `next`,
+/// and so forth, until either sequence completes or errors.
+///
+/// sequence - The sequence to zip with. This must not be `nil`.
+///
+/// Returns a new sequence of RACTuples, representing the combined values of the
+/// two sequences. Any error from one of the original sequence will be forwarded
+/// on the returned sequence.
+- (RACSequence *)zipWith:(RACSequence *)sequence;
+
+@end
+
+/// Redeclarations of operations built on the RACStream primitives with more
+/// precise type information.
+@interface RACSequence (RACStreamOperations)
+
+/// Maps `block` across the values in the receiver and flattens the result.
+///
+/// Note that operators applied _after_ -flattenMap: behave differently from
+/// operators _within_ -flattenMap:. See the Examples section below.
+///
+/// This corresponds to the `SelectMany` method in Rx.
+///
+/// block - A block which accepts the values in the receiver and returns a new
+///         instance of the receiver's class. Returning `nil` from this block is
+///         equivalent to returning an empty sequence.
+///
+/// Returns a new sequence which represents the combined sequences resulting
+/// from mapping `block`.
+- (RACSequence *)flattenMap:(__kindof RACSequence * _Nullable (^)(id _Nullable value))block;
+
+/// Flattens a sequence of sequences.
+///
+/// This corresponds to the `Merge` method in Rx.
+///
+/// Returns a sequence consisting of the combined sequences obtained from the
+/// receiver.
+- (RACSequence *)flatten;
+
+/// Maps `block` across the values in the receiver.
+///
+/// This corresponds to the `Select` method in Rx.
+///
+/// Returns a new sequence with the mapped values.
+- (RACSequence *)map:(id _Nullable (^)(id _Nullable value))block;
+
+/// Replaces each value in the receiver with the given object.
+///
+/// Returns a new sequence which includes the given object once for each value in
+/// the receiver.
+- (RACSequence *)mapReplace:(nullable id)object;
+
+/// Filters out values in the receiver that don't pass the given test.
+///
+/// This corresponds to the `Where` method in Rx.
+///
+/// Returns a new sequence with only those values that passed.
+- (RACSequence *)filter:(BOOL (^)(id _Nullable value))block;
+
+/// Filters out values in the receiver that equal (via -isEqual:) the provided
+/// value.
+///
+/// value - The value can be `nil`, in which case it ignores `nil` values.
+///
+/// Returns a new sequence containing only the values which did not compare
+/// equal to `value`.
+- (RACSequence *)ignore:(nullable id)value;
+
+/// Unpacks each RACTuple in the receiver and maps the values to a new value.
+///
+/// reduceBlock - The block which reduces each RACTuple's values into one value.
+///               It must take as many arguments as the number of tuple elements
+///               to process. Each argument will be an object argument. The
+///               return value must be an object. This argument cannot be nil.
+///
+/// Returns a new sequence of reduced tuple values.
+- (RACSequence *)reduceEach:(id _Nullable (^)())reduceBlock;
+
+/// Returns a sequence consisting of `value`, followed by the values in the
+/// receiver.
+- (RACSequence *)startWith:(nullable id)value;
+
+/// Skips the first `skipCount` values in the receiver.
+///
+/// Returns the receiver after skipping the first `skipCount` values. If
+/// `skipCount` is greater than the number of values in the sequence, an empty
+/// sequence is returned.
+- (RACSequence *)skip:(NSUInteger)skipCount;
+
+/// Returns a sequence of the first `count` values in the receiver. If `count` is
+/// greater than or equal to the number of values in the sequence, a sequence
+/// equivalent to the receiver is returned.
+- (RACSequence *)take:(NSUInteger)count;
+
+/// Zips the values in the given sequences to create RACTuples.
+///
+/// The first value of each sequence will be combined, then the second value,
+/// and so forth, until at least one of the sequences is exhausted.
+///
+/// sequences - The sequence to combine. If this collection is empty, the
+///             returned sequence will be empty.
+///
+/// Returns a new sequence containing RACTuples of the zipped values from the
+/// sequences.
++ (RACSequence *)zip:(id<NSFastEnumeration>)sequence;
+
+/// Zips sequences using +zip:, then reduces the resulting tuples into a single
+/// value using -reduceEach:
+///
+/// sequences   - The sequences to combine. If this collection is empty, the
+///               returned sequence will be empty.
+/// reduceBlock - The block which reduces the values from all the sequences
+///               into one value. It must take as many arguments as the
+///               number of sequences given. Each argument will be an object
+///               argument. The return value must be an object. This argument
+///               must not be nil.
+///
+/// Example:
+///
+///   [RACSequence zip:@[ stringSequence, intSequence ]
+///       reduce:^(NSString *string, NSNumber *number) {
+///           return [NSString stringWithFormat:@"%@: %@", string, number];
+///       }];
+///
+/// Returns a new sequence containing the results from each invocation of
+/// `reduceBlock`.
++ (RACSequence *)zip:(id<NSFastEnumeration>)sequences reduce:(id _Nullable (^)())reduceBlock;
+
+/// Returns a sequence obtained by concatenating `sequences` in order.
++ (RACSequence *)concat:(id<NSFastEnumeration>)sequences;
+
+/// Combines values in the receiver from left to right using the given block.
+///
+/// The algorithm proceeds as follows:
+///
+///  1. `startingValue` is passed into the block as the `running` value, and the
+///  first element of the receiver is passed into the block as the `next` value.
+///  2. The result of the invocation is added to the returned sequence.
+///  3. The result of the invocation (`running`) and the next element of the
+///  receiver (`next`) is passed into `block`.
+///  4. Steps 2 and 3 are repeated until all values have been processed.
+///
+/// startingValue - The value to be combined with the first element of the
+///                 receiver. This value may be `nil`.
+/// reduceBlock   - The block that describes how to combine values of the
+///                 receiver. If the receiver is empty, this block will never be
+///                 invoked. Cannot be nil.
+///
+/// Examples
+///
+///      RACSequence *numbers = @[ @1, @2, @3, @4 ].rac_sequence;
+///
+///      // Contains 1, 3, 6, 10
+///      RACSequence *sums = [numbers scanWithStart:@0 reduce:^(NSNumber *sum, NSNumber *next) {
+///          return @(sum.integerValue + next.integerValue);
+///      }];
+///
+/// Returns a new sequence that consists of each application of `reduceBlock`. If
+/// the receiver is empty, an empty sequence is returned.
+- (RACSequence *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, id _Nullable next))reduceBlock;
+
+/// Combines values in the receiver from left to right using the given block
+/// which also takes zero-based index of the values.
+///
+/// startingValue - The value to be combined with the first element of the
+///                 receiver. This value may be `nil`.
+/// reduceBlock   - The block that describes how to combine values of the
+///                 receiver. This block takes zero-based index value as the last
+///                 parameter. If the receiver is empty, this block will never
+///                 be invoked. Cannot be nil.
+///
+/// Returns a new sequence that consists of each application of `reduceBlock`.
+/// If the receiver is empty, an empty sequence is returned.
+- (RACSequence *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, id _Nullable next, NSUInteger index))reduceBlock;
+
+/// Combines each previous and current value into one object.
+///
+/// This method is similar to -scanWithStart:reduce:, but only ever operates on
+/// the previous and current values (instead of the whole sequence), and does
+/// not pass the return value of `reduceBlock` into the next invocation of it.
+///
+/// start       - The value passed into `reduceBlock` as `previous` for the
+///               first value.
+/// reduceBlock - The block that combines the previous value and the current
+///               value to create the reduced value. Cannot be nil.
+///
+/// Examples
+///
+///      RACSequence *numbers = [@[ @1, @2, @3, @4 ].rac_sequence;
+///
+///      // Contains 1, 3, 5, 7
+///      RACSequence *sums = [numbers combinePreviousWithStart:@0 reduce:^(NSNumber *previous, NSNumber *next) {
+///          return @(previous.integerValue + next.integerValue);
+///      }];
+///
+/// Returns a new sequence consisting of the return values from each application of
+/// `reduceBlock`.
+- (RACSequence *)combinePreviousWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable previous, id _Nullable current))reduceBlock;
+
+/// Takes values until the given block returns `YES`.
+///
+/// Returns a RACSequence of the initial values in the receiver that fail
+/// `predicate`. If `predicate` never returns `YES`, a sequence equivalent to
+/// the receiver is returned.
+- (RACSequence *)takeUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+
+/// Takes values until the given block returns `NO`.
+///
+/// Returns a sequence of the initial values in the receiver that pass
+/// `predicate`. If `predicate` never returns `NO`, a sequence equivalent to the
+/// receiver is returned.
+- (RACSequence *)takeWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+
+/// Skips values until the given block returns `YES`.
+///
+/// Returns a sequence containing the values of the receiver that follow any
+/// initial values failing `predicate`. If `predicate` never returns `YES`,
+/// an empty sequence is returned.
+- (RACSequence *)skipUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+
+/// Skips values until the given block returns `NO`.
+///
+/// Returns a sequence containing the values of the receiver that follow any
+/// initial values passing `predicate`. If `predicate` never returns `NO`, an
+/// empty sequence is returned.
+- (RACSequence *)skipWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+
+/// Returns a sequence of values for which -isEqual: returns NO when compared to
+/// the previous value.
+- (RACSequence *)distinctUntilChanged;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSequence.m
+++ b/ReactiveObjC/RACSequence.m
@@ -36,7 +36,7 @@
 //
 // Returns a new sequence which contains `current`, followed by the combined
 // result of all applications of `block` to the remaining values in the receiver.
-- (instancetype)bind:(RACStreamBindBlock)block passingThroughValuesFromSequence:(RACSequence *)current;
+- (RACSequence *)bind:(RACSequenceBindBlock)block passingThroughValuesFromSequence:(RACSequence *)current;
 
 @end
 
@@ -77,20 +77,20 @@
 
 #pragma mark RACStream
 
-+ (instancetype)empty {
++ (RACSequence *)empty {
 	return RACEmptySequence.empty;
 }
 
-+ (instancetype)return:(id)value {
++ (RACSequence *)return:(id)value {
 	return [RACUnarySequence return:value];
 }
 
-- (instancetype)bind:(RACStreamBindBlock (^)(void))block {
-	RACStreamBindBlock bindBlock = block();
+- (RACSequence *)bind:(RACSequenceBindBlock (^)(void))block {
+	RACSequenceBindBlock bindBlock = block();
 	return [[self bind:bindBlock passingThroughValuesFromSequence:nil] setNameWithFormat:@"[%@] -bind:", self.name];
 }
 
-- (instancetype)bind:(RACStreamBindBlock)bindBlock passingThroughValuesFromSequence:(RACSequence *)passthroughSequence {
+- (RACSequence *)bind:(RACSequenceBindBlock)bindBlock passingThroughValuesFromSequence:(RACSequence *)passthroughSequence {
 	// Store values calculated in the dependency here instead, avoiding any kind
 	// of temporary collection and boxing.
 	//
@@ -138,15 +138,15 @@
 	return sequence;
 }
 
-- (instancetype)concat:(RACStream *)stream {
-	NSCParameterAssert(stream != nil);
+- (RACSequence *)concat:(RACSequence *)sequence {
+	NSCParameterAssert(sequence != nil);
 
-	return [[[RACArraySequence sequenceWithArray:@[ self, stream ] offset:0]
+	return [[[RACArraySequence sequenceWithArray:@[ self, sequence ] offset:0]
 		flatten]
-		setNameWithFormat:@"[%@] -concat: %@", self.name, stream];
+		setNameWithFormat:@"[%@] -concat: %@", self.name, sequence];
 }
 
-- (instancetype)zipWith:(RACSequence *)sequence {
+- (RACSequence *)zipWith:(RACSequence *)sequence {
 	NSCParameterAssert(sequence != nil);
 
 	return [[RACSequence

--- a/ReactiveObjC/RACSignal.m
+++ b/ReactiveObjC/RACSignal.m
@@ -90,7 +90,7 @@
 	return [RACReturnSignal return:value];
 }
 
-- (RACSignal *)bind:(RACStreamBindBlock (^)(void))block {
+- (RACSignal *)bind:(RACSignalBindBlock (^)(void))block {
 	NSCParameterAssert(block != NULL);
 
 	/*
@@ -106,7 +106,7 @@
 	 */
 
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACStreamBindBlock bindingBlock = block();
+		RACSignalBindBlock bindingBlock = block();
 
 		__block volatile int32_t signalCount = 1;   // indicates self
 

--- a/ReactiveObjC/RACStream+Private.h
+++ b/ReactiveObjC/RACStream+Private.h
@@ -18,6 +18,6 @@
 //           values.
 //
 // Returns a combined stream.
-+ (instancetype)join:(id<NSFastEnumeration>)streams block:(RACStream * (^)(id, id))block;
++ (__kindof RACStream *)join:(id<NSFastEnumeration>)streams block:(RACStream * (^)(id, id))block;
 
 @end

--- a/ReactiveObjC/RACStream.h
+++ b/ReactiveObjC/RACStream.h
@@ -29,12 +29,12 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 @interface RACStream : NSObject
 
 /// Returns an empty stream.
-+ (instancetype)empty;
++ (__kindof RACStream *)empty;
 
 /// Lifts `value` into the stream monad.
 ///
 /// Returns a stream containing only the given value.
-+ (instancetype)return:(nullable id)value;
++ (__kindof RACStream *)return:(nullable id)value;
 
 /// Lazily binds a block to the values in the receiver.
 ///
@@ -47,7 +47,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream which represents the combined result of all lazy
 /// applications of `block`.
-- (instancetype)bind:(RACStreamBindBlock (^)(void))block;
+- (__kindof RACStream *)bind:(RACStreamBindBlock (^)(void))block;
 
 /// Appends the values of `stream` to the values in the receiver.
 ///
@@ -55,7 +55,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///          concrete class as the receiver, and should not be `nil`.
 ///
 /// Returns a new stream representing the receiver followed by `stream`.
-- (instancetype)concat:(RACStream *)stream;
+- (__kindof RACStream *)concat:(RACStream *)stream;
 
 /// Zips the values in the receiver with those of the given stream to create
 /// RACTuples.
@@ -68,7 +68,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream of RACTuples, representing the zipped values of the
 /// two streams.
-- (instancetype)zipWith:(RACStream *)stream;
+- (__kindof RACStream *)zipWith:(RACStream *)stream;
 
 @end
 
@@ -124,7 +124,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream which represents the combined streams resulting from
 /// mapping `block`.
-- (instancetype)flattenMap:(RACStream * _Nullable (^)(id _Nullable value))block;
+- (__kindof RACStream *)flattenMap:(__kindof RACStream * _Nullable (^)(id _Nullable value))block;
 
 /// Flattens a stream of streams.
 ///
@@ -132,27 +132,27 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a stream consisting of the combined streams obtained from the
 /// receiver.
-- (instancetype)flatten;
+- (__kindof RACStream *)flatten;
 
 /// Maps `block` across the values in the receiver.
 ///
 /// This corresponds to the `Select` method in Rx.
 ///
 /// Returns a new stream with the mapped values.
-- (instancetype)map:(id _Nullable (^)(id _Nullable value))block;
+- (__kindof RACStream *)map:(id _Nullable (^)(id _Nullable value))block;
 
 /// Replaces each value in the receiver with the given object.
 ///
 /// Returns a new stream which includes the given object once for each value in
 /// the receiver.
-- (instancetype)mapReplace:(nullable id)object;
+- (__kindof RACStream *)mapReplace:(nullable id)object;
 
 /// Filters out values in the receiver that don't pass the given test.
 ///
 /// This corresponds to the `Where` method in Rx.
 ///
 /// Returns a new stream with only those values that passed.
-- (instancetype)filter:(BOOL (^)(id _Nullable value))block;
+- (__kindof RACStream *)filter:(BOOL (^)(id _Nullable value))block;
 
 /// Filters out values in the receiver that equal (via -isEqual:) the provided value.
 ///
@@ -160,7 +160,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream containing only the values which did not compare equal
 /// to `value`.
-- (instancetype)ignore:(nullable id)value;
+- (__kindof RACStream *)ignore:(nullable id)value;
 
 /// Unpacks each RACTuple in the receiver and maps the values to a new value.
 ///
@@ -170,23 +170,23 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///               return value must be an object. This argument cannot be nil.
 ///
 /// Returns a new stream of reduced tuple values.
-- (instancetype)reduceEach:(id _Nullable (^)())reduceBlock;
+- (__kindof RACStream *)reduceEach:(id _Nullable (^)())reduceBlock;
 
 /// Returns a stream consisting of `value`, followed by the values in the
 /// receiver.
-- (instancetype)startWith:(nullable id)value;
+- (__kindof RACStream *)startWith:(nullable id)value;
 
 /// Skips the first `skipCount` values in the receiver.
 ///
 /// Returns the receiver after skipping the first `skipCount` values. If
 /// `skipCount` is greater than the number of values in the stream, an empty
 /// stream is returned.
-- (instancetype)skip:(NSUInteger)skipCount;
+- (__kindof RACStream *)skip:(NSUInteger)skipCount;
 
 /// Returns a stream of the first `count` values in the receiver. If `count` is
 /// greater than or equal to the number of values in the stream, a stream
 /// equivalent to the receiver is returned.
-- (instancetype)take:(NSUInteger)count;
+- (__kindof RACStream *)take:(NSUInteger)count;
 
 /// Zips the values in the given streams to create RACTuples.
 ///
@@ -199,7 +199,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream containing RACTuples of the zipped values from the
 /// streams.
-+ (instancetype)zip:(id<NSFastEnumeration>)streams;
++ (__kindof RACStream *)zip:(id<NSFastEnumeration>)streams;
 
 /// Zips streams using +zip:, then reduces the resulting tuples into a single
 /// value using -reduceEach:
@@ -221,10 +221,10 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream containing the results from each invocation of
 /// `reduceBlock`.
-+ (instancetype)zip:(id<NSFastEnumeration>)streams reduce:(id _Nullable (^)())reduceBlock;
++ (__kindof RACStream *)zip:(id<NSFastEnumeration>)streams reduce:(id _Nullable (^)())reduceBlock;
 
 /// Returns a stream obtained by concatenating `streams` in order.
-+ (instancetype)concat:(id<NSFastEnumeration>)streams;
++ (__kindof RACStream *)concat:(id<NSFastEnumeration>)streams;
 
 /// Combines values in the receiver from left to right using the given block.
 ///
@@ -254,7 +254,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream that consists of each application of `reduceBlock`. If the
 /// receiver is empty, an empty stream is returned.
-- (instancetype)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, id _Nullable next))reduceBlock;
+- (__kindof RACStream *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, id _Nullable next))reduceBlock;
 
 /// Combines values in the receiver from left to right using the given block
 /// which also takes zero-based index of the values.
@@ -268,7 +268,7 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream that consists of each application of `reduceBlock`. If the
 /// receiver is empty, an empty stream is returned.
-- (instancetype)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, id _Nullable next, NSUInteger index))reduceBlock;
+- (__kindof RACStream *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, id _Nullable next, NSUInteger index))reduceBlock;
 
 /// Combines each previous and current value into one object.
 ///
@@ -292,39 +292,39 @@ typedef RACStream * _Nullable (^RACStreamBindBlock)(id _Nullable value, BOOL *st
 ///
 /// Returns a new stream consisting of the return values from each application of
 /// `reduceBlock`.
-- (instancetype)combinePreviousWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable previous, id _Nullable current))reduceBlock;
+- (__kindof RACStream *)combinePreviousWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable previous, id _Nullable current))reduceBlock;
 
 /// Takes values until the given block returns `YES`.
 ///
 /// Returns a stream of the initial values in the receiver that fail `predicate`.
 /// If `predicate` never returns `YES`, a stream equivalent to the receiver is
 /// returned.
-- (instancetype)takeUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+- (__kindof RACStream *)takeUntilBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Takes values until the given block returns `NO`.
 ///
 /// Returns a stream of the initial values in the receiver that pass `predicate`.
 /// If `predicate` never returns `NO`, a stream equivalent to the receiver is
 /// returned.
-- (instancetype)takeWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+- (__kindof RACStream *)takeWhileBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Skips values until the given block returns `YES`.
 ///
 /// Returns a stream containing the values of the receiver that follow any
 /// initial values failing `predicate`. If `predicate` never returns `YES`,
 /// an empty stream is returned.
-- (instancetype)skipUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+- (__kindof RACStream *)skipUntilBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Skips values until the given block returns `NO`.
 ///
 /// Returns a stream containing the values of the receiver that follow any
 /// initial values passing `predicate`. If `predicate` never returns `NO`, an
 /// empty stream is returned.
-- (instancetype)skipWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+- (__kindof RACStream *)skipWhileBlock:(BOOL (^)(id _Nullable x))predicate;
 
 /// Returns a stream of values for which -isEqual: returns NO when compared to the
 /// previous value.
-- (instancetype)distinctUntilChanged;
+- (__kindof RACStream *)distinctUntilChanged;
 
 @end
 

--- a/ReactiveObjC/RACStream.m
+++ b/ReactiveObjC/RACStream.m
@@ -24,27 +24,27 @@
 
 #pragma mark Abstract methods
 
-+ (instancetype)empty {
++ (__kindof RACStream *)empty {
 	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
 	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
-- (instancetype)bind:(RACStreamBindBlock (^)(void))block {
+- (__kindof RACStream *)bind:(RACStreamBindBlock (^)(void))block {
 	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
 	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
-+ (instancetype)return:(id)value {
++ (__kindof RACStream *)return:(id)value {
 	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
 	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
-- (instancetype)concat:(RACStream *)stream {
+- (__kindof RACStream *)concat:(RACStream *)stream {
 	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
 	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
 
-- (instancetype)zipWith:(RACStream *)stream {
+- (__kindof RACStream *)zipWith:(RACStream *)stream {
 	NSString *reason = [NSString stringWithFormat:@"%@ must be overridden by subclasses", NSStringFromSelector(_cmd)];
 	@throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
 }
@@ -70,7 +70,7 @@
 
 @implementation RACStream (Operations)
 
-- (instancetype)flattenMap:(RACStream * (^)(id value))block {
+- (__kindof RACStream *)flattenMap:(__kindof RACStream * (^)(id value))block {
 	Class class = self.class;
 
 	return [[self bind:^{
@@ -83,13 +83,13 @@
 	}] setNameWithFormat:@"[%@] -flattenMap:", self.name];
 }
 
-- (instancetype)flatten {
+- (__kindof RACStream *)flatten {
 	return [[self flattenMap:^(id value) {
 		return value;
 	}] setNameWithFormat:@"[%@] -flatten", self.name];
 }
 
-- (instancetype)map:(id (^)(id value))block {
+- (__kindof RACStream *)map:(id (^)(id value))block {
 	NSCParameterAssert(block != nil);
 
 	Class class = self.class;
@@ -99,13 +99,13 @@
 	}] setNameWithFormat:@"[%@] -map:", self.name];
 }
 
-- (instancetype)mapReplace:(id)object {
+- (__kindof RACStream *)mapReplace:(id)object {
 	return [[self map:^(id _) {
 		return object;
 	}] setNameWithFormat:@"[%@] -mapReplace: %@", self.name, RACDescription(object)];
 }
 
-- (instancetype)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id next))reduceBlock {
+- (__kindof RACStream *)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id next))reduceBlock {
 	NSCParameterAssert(reduceBlock != NULL);
 	return [[[self
 		scanWithStart:RACTuplePack(start)
@@ -119,7 +119,7 @@
 		setNameWithFormat:@"[%@] -combinePreviousWithStart: %@ reduce:", self.name, RACDescription(start)];
 }
 
-- (instancetype)filter:(BOOL (^)(id value))block {
+- (__kindof RACStream *)filter:(BOOL (^)(id value))block {
 	NSCParameterAssert(block != nil);
 
 	Class class = self.class;
@@ -133,13 +133,13 @@
 	}] setNameWithFormat:@"[%@] -filter:", self.name];
 }
 
-- (instancetype)ignore:(id)value {
+- (__kindof RACStream *)ignore:(id)value {
 	return [[self filter:^ BOOL (id innerValue) {
 		return innerValue != value && ![innerValue isEqual:value];
 	}] setNameWithFormat:@"[%@] -ignore: %@", self.name, RACDescription(value)];
 }
 
-- (instancetype)reduceEach:(id (^)())reduceBlock {
+- (__kindof RACStream *)reduceEach:(id (^)())reduceBlock {
 	NSCParameterAssert(reduceBlock != nil);
 
 	__weak RACStream *stream __attribute__((unused)) = self;
@@ -149,13 +149,13 @@
 	}] setNameWithFormat:@"[%@] -reduceEach:", self.name];
 }
 
-- (instancetype)startWith:(id)value {
+- (__kindof RACStream *)startWith:(id)value {
 	return [[[self.class return:value]
 		concat:self]
 		setNameWithFormat:@"[%@] -startWith: %@", self.name, RACDescription(value)];
 }
 
-- (instancetype)skip:(NSUInteger)skipCount {
+- (__kindof RACStream *)skip:(NSUInteger)skipCount {
 	Class class = self.class;
 	
 	return [[self bind:^{
@@ -170,7 +170,7 @@
 	}] setNameWithFormat:@"[%@] -skip: %lu", self.name, (unsigned long)skipCount];
 }
 
-- (instancetype)take:(NSUInteger)count {
+- (__kindof RACStream *)take:(NSUInteger)count {
 	Class class = self.class;
 	
 	if (count == 0) return class.empty;
@@ -190,7 +190,7 @@
 	}] setNameWithFormat:@"[%@] -take: %lu", self.name, (unsigned long)count];
 }
 
-+ (instancetype)join:(id<NSFastEnumeration>)streams block:(RACStream * (^)(id, id))block {
++ (__kindof RACStream *)join:(id<NSFastEnumeration>)streams block:(RACStream * (^)(id, id))block {
 	RACStream *current = nil;
 
 	// Creates streams of successively larger tuples by combining the input
@@ -228,13 +228,13 @@
 	}];
 }
 
-+ (instancetype)zip:(id<NSFastEnumeration>)streams {
++ (__kindof RACStream *)zip:(id<NSFastEnumeration>)streams {
 	return [[self join:streams block:^(RACStream *left, RACStream *right) {
 		return [left zipWith:right];
 	}] setNameWithFormat:@"+zip: %@", streams];
 }
 
-+ (instancetype)zip:(id<NSFastEnumeration>)streams reduce:(id (^)())reduceBlock {
++ (__kindof RACStream *)zip:(id<NSFastEnumeration>)streams reduce:(id (^)())reduceBlock {
 	NSCParameterAssert(reduceBlock != nil);
 
 	RACStream *result = [self zip:streams];
@@ -247,7 +247,7 @@
 	return [result setNameWithFormat:@"+zip: %@ reduce:", streams];
 }
 
-+ (instancetype)concat:(id<NSFastEnumeration>)streams {
++ (__kindof RACStream *)concat:(id<NSFastEnumeration>)streams {
 	RACStream *result = self.empty;
 	for (RACStream *stream in streams) {
 		result = [result concat:stream];
@@ -256,7 +256,7 @@
 	return [result setNameWithFormat:@"+concat: %@", streams];
 }
 
-- (instancetype)scanWithStart:(id)startingValue reduce:(id (^)(id running, id next))reduceBlock {
+- (__kindof RACStream *)scanWithStart:(id)startingValue reduce:(id (^)(id running, id next))reduceBlock {
 	NSCParameterAssert(reduceBlock != nil);
 
 	return [[self
@@ -267,7 +267,7 @@
 		setNameWithFormat:@"[%@] -scanWithStart: %@ reduce:", self.name, RACDescription(startingValue)];
 }
 
-- (instancetype)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
+- (__kindof RACStream *)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
 	NSCParameterAssert(reduceBlock != nil);
 
 	Class class = self.class;
@@ -283,7 +283,7 @@
 	}] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name, RACDescription(startingValue)];
 }
 
-- (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate {
+- (__kindof RACStream *)takeUntilBlock:(BOOL (^)(id x))predicate {
 	NSCParameterAssert(predicate != nil);
 
 	Class class = self.class;
@@ -297,7 +297,7 @@
 	}] setNameWithFormat:@"[%@] -takeUntilBlock:", self.name];
 }
 
-- (instancetype)takeWhileBlock:(BOOL (^)(id x))predicate {
+- (__kindof RACStream *)takeWhileBlock:(BOOL (^)(id x))predicate {
 	NSCParameterAssert(predicate != nil);
 
 	return [[self takeUntilBlock:^ BOOL (id x) {
@@ -305,7 +305,7 @@
 	}] setNameWithFormat:@"[%@] -takeWhileBlock:", self.name];
 }
 
-- (instancetype)skipUntilBlock:(BOOL (^)(id x))predicate {
+- (__kindof RACStream *)skipUntilBlock:(BOOL (^)(id x))predicate {
 	NSCParameterAssert(predicate != nil);
 
 	Class class = self.class;
@@ -327,7 +327,7 @@
 	}] setNameWithFormat:@"[%@] -skipUntilBlock:", self.name];
 }
 
-- (instancetype)skipWhileBlock:(BOOL (^)(id x))predicate {
+- (__kindof RACStream *)skipWhileBlock:(BOOL (^)(id x))predicate {
 	NSCParameterAssert(predicate != nil);
 
 	return [[self skipUntilBlock:^ BOOL (id x) {
@@ -335,7 +335,7 @@
 	}] setNameWithFormat:@"[%@] -skipWhileBlock:", self.name];
 }
 
-- (instancetype)distinctUntilChanged {
+- (__kindof RACStream *)distinctUntilChanged {
 	Class class = self.class;
 
 	return [[self bind:^{

--- a/ReactiveObjC/RACTupleSequence.h
+++ b/ReactiveObjC/RACTupleSequence.h
@@ -13,6 +13,6 @@
 
 // Returns a sequence for enumerating over the given backing array (from a
 // RACTuple), starting from the given offset.
-+ (instancetype)sequenceWithTupleBackingArray:(NSArray *)backingArray offset:(NSUInteger)offset;
++ (RACSequence *)sequenceWithTupleBackingArray:(NSArray *)backingArray offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveObjC/RACTupleSequence.m
+++ b/ReactiveObjC/RACTupleSequence.m
@@ -23,7 +23,7 @@
 
 #pragma mark Lifecycle
 
-+ (instancetype)sequenceWithTupleBackingArray:(NSArray *)backingArray offset:(NSUInteger)offset {
++ (RACSequence *)sequenceWithTupleBackingArray:(NSArray *)backingArray offset:(NSUInteger)offset {
 	NSCParameterAssert(offset <= backingArray.count);
 
 	if (offset == backingArray.count) return self.empty;

--- a/ReactiveObjC/RACUnarySequence.h
+++ b/ReactiveObjC/RACUnarySequence.h
@@ -11,4 +11,6 @@
 // Private class representing a sequence of exactly one value.
 @interface RACUnarySequence : RACSequence
 
++ (RACUnarySequence *)return:(id)value;
+
 @end

--- a/ReactiveObjC/RACUnarySequence.m
+++ b/ReactiveObjC/RACUnarySequence.m
@@ -25,7 +25,7 @@
 
 #pragma mark Lifecycle
 
-+ (instancetype)return:(id)value {
++ (RACUnarySequence *)return:(id)value {
 	RACUnarySequence *sequence = [[self alloc] init];
 	sequence.head = value;
 	return [sequence setNameWithFormat:@"+return: %@", RACDescription(value)];
@@ -37,7 +37,7 @@
 	return nil;
 }
 
-- (instancetype)bind:(RACStreamBindBlock (^)(void))block {
+- (RACSequence *)bind:(RACSequenceBindBlock (^)(void))block {
 	RACStreamBindBlock bindBlock = block();
 	BOOL stop = NO;
 


### PR DESCRIPTION
Redeclares operations built on RACStream primitives with more precise type information. This continues the work from #37 by adding the RACStream operators RACSequence, and updating RACStream methods to return `__kindof RACStream`.

This will allow lightweight generics to be added to `RACSequence` quite easily (following the same pattern as RACSignal), if desired.

I have verified that this fixes issue #40 by testing out the code in the issue. This is fixed by giving less precise type information to the `RACSteam` operator return values (`__kindof RACStream *`, rather than `instancetype`, as before), so that the compiler references the `RACSignal` version.

Additionally, I have verified that our large ReactiveCocoa 2.x codebase can be successfully migrated with these changes without any other issues like #40.