### PR TITLE
Add ValueType lightweight generic to RACSequence

### DIFF
--- a/ReactiveObjC/NSArray+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSArray+RACSequenceAdditions.h
@@ -8,16 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSArray (RACSequenceAdditions)
+@interface NSArray<__covariant ObjectType> (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<ObjectType> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
@@ -8,27 +8,28 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
+@class RACTuple;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSDictionary (RACSequenceAdditions)
+@interface NSDictionary<__covariant KeyType, __covariant ObjectType> (RACSequenceAdditions)
 
 /// Creates and returns a sequence of RACTuple key/value pairs. The key will be
 /// the first element in the tuple, and the value will be the second.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<RACTuple *> *rac_sequence;
 
 /// Creates and returns a sequence corresponding to the keys in the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_keySequence;
+@property (nonatomic, copy, readonly) RACSequence<KeyType> *rac_keySequence;
 
 /// Creates and returns a sequence corresponding to the values in the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_valueSequence;
+@property (nonatomic, copy, readonly) RACSequence<ObjectType> *rac_valueSequence;
 
 @end
 

--- a/ReactiveObjC/NSEnumerator+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSEnumerator+RACSequenceAdditions.h
@@ -8,16 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSEnumerator (RACSequenceAdditions)
+@interface NSEnumerator<ObjectType> (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
 ///
 /// The receiver is exhausted lazily as the sequence is enumerated.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<ObjectType> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/NSIndexSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSIndexSet+RACSequenceAdditions.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<NSNumber *> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/NSOrderedSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSOrderedSet+RACSequenceAdditions.h
@@ -8,16 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSOrderedSet (RACSequenceAdditions)
+@interface NSOrderedSet<__covariant ObjectType> (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<ObjectType> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/NSSet+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSSet+RACSequenceAdditions.h
@@ -8,16 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSSet (RACSequenceAdditions)
+@interface NSSet<__covariant ObjectType> (RACSequenceAdditions)
 
 /// Creates and returns a sequence corresponding to the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<ObjectType> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/NSString+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSString+RACSequenceAdditions.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// composed character sequence in the receiver.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<NSString *> *rac_sequence;
 
 @end
 

--- a/ReactiveObjC/RACDynamicSequence.m
+++ b/ReactiveObjC/RACDynamicSequence.m
@@ -91,7 +91,7 @@
 
 #pragma mark Lifecycle
 
-+ (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock {
++ (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence<id> *(^)(void))tailBlock {
 	NSCParameterAssert(headBlock != nil);
 
 	RACDynamicSequence *seq = [[RACDynamicSequence alloc] init];

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -25,24 +25,24 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Implemented as a class cluster. A minimal implementation for a subclass
 /// consists simply of -head and -tail.
-@interface RACSequence : RACStream <NSCoding, NSCopying, NSFastEnumeration>
+@interface RACSequence<__covariant ValueType> : RACStream <NSCoding, NSCopying, NSFastEnumeration>
 
 /// The first object in the sequence, or nil if the sequence is empty.
 ///
 /// Subclasses must provide an implementation of this method.
-@property (nonatomic, strong, readonly, nullable) id head;
+@property (nonatomic, strong, readonly, nullable) ValueType head;
 
 /// All but the first object in the sequence, or nil if there are no other
 /// objects.
 ///
 /// Subclasses must provide an implementation of this method.
-@property (nonatomic, strong, readonly, nullable) RACSequence *tail;
+@property (nonatomic, strong, readonly, nullable) RACSequence<ValueType> *tail;
 
 /// Evaluates the full sequence to produce an equivalently-sized array.
-@property (nonatomic, copy, readonly) NSArray *array;
+@property (nonatomic, copy, readonly) NSArray<ValueType> *array;
 
 /// Returns an enumerator of all objects in the sequence.
-@property (nonatomic, copy, readonly) NSEnumerator *objectEnumerator;
+@property (nonatomic, copy, readonly) NSEnumerator<ValueType> *objectEnumerator;
 
 /// Converts a sequence into an eager sequence.
 ///
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns a new eager sequence, or the receiver if the sequence is already
 /// eager.
-@property (nonatomic, copy, readonly) RACSequence *eagerSequence;
+@property (nonatomic, copy, readonly) RACSequence<ValueType> *eagerSequence;
 
 /// Converts a sequence into a lazy sequence.
 ///
@@ -59,10 +59,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// Sequences derived from a lazy sequence will also be lazy.
 ///
 /// Returns a new lazy sequence, or the receiver if the sequence is already lazy.
-@property (nonatomic, copy, readonly) RACSequence *lazySequence;
+@property (nonatomic, copy, readonly) RACSequence<ValueType> *lazySequence;
 
 /// Invokes -signalWithScheduler: with a new RACScheduler.
-- (RACSignal *)signal;
+- (RACSignal<ValueType> *)signal;
 
 /// Evaluates the full sequence on the given scheduler.
 ///
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns a signal which sends the receiver's values on the given scheduler as
 /// they're evaluated.
-- (RACSignal *)signalWithScheduler:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)signalWithScheduler:(RACScheduler *)scheduler;
 
 /// Applies a left fold to the sequence.
 ///
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///          Cannot be nil.
 ///
 /// Returns a reduced value.
-- (id)foldLeftWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable accumulator, id _Nullable value))reduce;
+- (id)foldLeftWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable accumulator, ValueType _Nullable value))reduce;
 
 /// Applies a right fold to the sequence.
 ///
@@ -112,21 +112,21 @@ NS_ASSUME_NONNULL_BEGIN
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns a boolean indiciating if any value in the sequence passed.
-- (BOOL)any:(BOOL (^)(id _Nullable value))block;
+- (BOOL)any:(BOOL (^)(ValueType _Nullable value))block;
 
 /// Check if all values in the sequence pass the block.
 ///
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns a boolean indicating if all values in the sequence passed.
-- (BOOL)all:(BOOL (^)(id _Nullable value))block;
+- (BOOL)all:(BOOL (^)(ValueType _Nullable value))block;
 
 /// Returns the first object that passes the block.
 ///
 /// block - The block predicate used to check each item. Cannot be nil.
 ///
 /// Returns an object that passes the block or nil if no objects passed.
-- (id)objectPassingTest:(BOOL (^)(id _Nullable value))block;
+- (id)objectPassingTest:(BOOL (^)(ValueType _Nullable value))block;
 
 /// Creates a sequence that dynamically generates its values.
 ///
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns a sequence that lazily invokes the given blocks to provide head and
 /// tail. `headBlock` must not be nil.
-+ (RACSequence *)sequenceWithHeadBlock:(id _Nullable (^)(void))headBlock tailBlock:(nullable RACSequence *(^)(void))tailBlock;
++ (RACSequence<ValueType> *)sequenceWithHeadBlock:(ValueType _Nullable (^)(void))headBlock tailBlock:(nullable RACSequence<ValueType> *(^)(void))tailBlock;
 
 @end
 
@@ -155,13 +155,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// value. Returning `nil` will result in immediate termination.
 typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL *stop);
 
-@interface RACSequence (RACStream)
+@interface RACSequence<__covariant ValueType> (RACStream)
 
 /// Returns a sequence that immediately sends the given value and then completes.
-+ (RACSequence *)return:(nullable)value;
++ (RACSequence<ValueType> *)return:(nullable ValueType)value;
 
 /// Returns a sequence that immediately completes.
-+ (RACSequence *)empty;
++ (RACSequence<ValueType> *)empty;
 
 /// Lazily binds a block to the values in the receiver.
 ///
@@ -196,7 +196,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 
 /// Redeclarations of operations built on the RACStream primitives with more
 /// precise type information.
-@interface RACSequence (RACStreamOperations)
+@interface RACSequence<__covariant ValueType> (RACStreamOperations)
 
 /// Maps `block` across the values in the receiver and flattens the result.
 ///
@@ -211,7 +211,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence which represents the combined sequences resulting
 /// from mapping `block`.
-- (RACSequence *)flattenMap:(__kindof RACSequence * _Nullable (^)(id _Nullable value))block;
+- (RACSequence *)flattenMap:(__kindof RACSequence * _Nullable (^)(ValueType _Nullable value))block;
 
 /// Flattens a sequence of sequences.
 ///
@@ -226,7 +226,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 /// This corresponds to the `Select` method in Rx.
 ///
 /// Returns a new sequence with the mapped values.
-- (RACSequence *)map:(id _Nullable (^)(id _Nullable value))block;
+- (RACSequence *)map:(id _Nullable (^)(ValueType _Nullable value))block;
 
 /// Replaces each value in the receiver with the given object.
 ///
@@ -239,7 +239,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 /// This corresponds to the `Where` method in Rx.
 ///
 /// Returns a new sequence with only those values that passed.
-- (RACSequence *)filter:(BOOL (^)(id _Nullable value))block;
+- (RACSequence<ValueType> *)filter:(BOOL (^)(id _Nullable value))block;
 
 /// Filters out values in the receiver that equal (via -isEqual:) the provided
 /// value.
@@ -248,7 +248,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence containing only the values which did not compare
 /// equal to `value`.
-- (RACSequence *)ignore:(nullable id)value;
+- (RACSequence *)ignore:(nullable ValueType)value;
 
 /// Unpacks each RACTuple in the receiver and maps the values to a new value.
 ///
@@ -262,19 +262,19 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 
 /// Returns a sequence consisting of `value`, followed by the values in the
 /// receiver.
-- (RACSequence *)startWith:(nullable id)value;
+- (RACSequence<ValueType> *)startWith:(nullable ValueType)value;
 
 /// Skips the first `skipCount` values in the receiver.
 ///
 /// Returns the receiver after skipping the first `skipCount` values. If
 /// `skipCount` is greater than the number of values in the sequence, an empty
 /// sequence is returned.
-- (RACSequence *)skip:(NSUInteger)skipCount;
+- (RACSequence<ValueType> *)skip:(NSUInteger)skipCount;
 
 /// Returns a sequence of the first `count` values in the receiver. If `count` is
 /// greater than or equal to the number of values in the sequence, a sequence
 /// equivalent to the receiver is returned.
-- (RACSequence *)take:(NSUInteger)count;
+- (RACSequence<ValueType> *)take:(NSUInteger)count;
 
 /// Zips the values in the given sequences to create RACTuples.
 ///
@@ -286,7 +286,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence containing RACTuples of the zipped values from the
 /// sequences.
-+ (RACSequence *)zip:(id<NSFastEnumeration>)sequence;
++ (RACSequence<ValueType> *)zip:(id<NSFastEnumeration>)sequence;
 
 /// Zips sequences using +zip:, then reduces the resulting tuples into a single
 /// value using -reduceEach:
@@ -308,10 +308,10 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence containing the results from each invocation of
 /// `reduceBlock`.
-+ (RACSequence *)zip:(id<NSFastEnumeration>)sequences reduce:(id _Nullable (^)())reduceBlock;
++ (RACSequence<ValueType> *)zip:(id<NSFastEnumeration>)sequences reduce:(id _Nullable (^)())reduceBlock;
 
 /// Returns a sequence obtained by concatenating `sequences` in order.
-+ (RACSequence *)concat:(id<NSFastEnumeration>)sequences;
++ (RACSequence<ValueType> *)concat:(id<NSFastEnumeration>)sequences;
 
 /// Combines values in the receiver from left to right using the given block.
 ///
@@ -341,7 +341,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence that consists of each application of `reduceBlock`. If
 /// the receiver is empty, an empty sequence is returned.
-- (RACSequence *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, id _Nullable next))reduceBlock;
+- (RACSequence *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next))reduceBlock;
 
 /// Combines values in the receiver from left to right using the given block
 /// which also takes zero-based index of the values.
@@ -355,7 +355,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence that consists of each application of `reduceBlock`.
 /// If the receiver is empty, an empty sequence is returned.
-- (RACSequence *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, id _Nullable next, NSUInteger index))reduceBlock;
+- (RACSequence *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next, NSUInteger index))reduceBlock;
 
 /// Combines each previous and current value into one object.
 ///
@@ -379,39 +379,39 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(id _Nullable value, BOOL
 ///
 /// Returns a new sequence consisting of the return values from each application of
 /// `reduceBlock`.
-- (RACSequence *)combinePreviousWithStart:(nullable id)start reduce:(id _Nullable (^)(id _Nullable previous, id _Nullable current))reduceBlock;
+- (RACSequence *)combinePreviousWithStart:(nullable ValueType)start reduce:(id _Nullable (^)(ValueType _Nullable previous, ValueType _Nullable current))reduceBlock;
 
 /// Takes values until the given block returns `YES`.
 ///
 /// Returns a RACSequence of the initial values in the receiver that fail
 /// `predicate`. If `predicate` never returns `YES`, a sequence equivalent to
 /// the receiver is returned.
-- (RACSequence *)takeUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+- (RACSequence<ValueType> *)takeUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate;
 
 /// Takes values until the given block returns `NO`.
 ///
 /// Returns a sequence of the initial values in the receiver that pass
 /// `predicate`. If `predicate` never returns `NO`, a sequence equivalent to the
 /// receiver is returned.
-- (RACSequence *)takeWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+- (RACSequence<ValueType> *)takeWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate;
 
 /// Skips values until the given block returns `YES`.
 ///
 /// Returns a sequence containing the values of the receiver that follow any
 /// initial values failing `predicate`. If `predicate` never returns `YES`,
 /// an empty sequence is returned.
-- (RACSequence *)skipUntilBlock:(BOOL (^)(id _Nullable x))predicate;
+- (RACSequence<ValueType> *)skipUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate;
 
 /// Skips values until the given block returns `NO`.
 ///
 /// Returns a sequence containing the values of the receiver that follow any
 /// initial values passing `predicate`. If `predicate` never returns `NO`, an
 /// empty sequence is returned.
-- (RACSequence *)skipWhileBlock:(BOOL (^)(id _Nullable x))predicate;
+- (RACSequence<ValueType> *)skipWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate;
 
 /// Returns a sequence of values for which -isEqual: returns NO when compared to
 /// the previous value.
-- (RACSequence *)distinctUntilChanged;
+- (RACSequence<ValueType> *)distinctUntilChanged;
 
 @end
 

--- a/ReactiveObjC/RACSequence.m
+++ b/ReactiveObjC/RACSequence.m
@@ -59,7 +59,7 @@
 
 #pragma mark Lifecycle
 
-+ (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock {
++ (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence<id> *(^)(void))tailBlock {
 	return [[RACDynamicSequence sequenceWithHeadBlock:headBlock tailBlock:tailBlock] setNameWithFormat:@"+sequenceWithHeadBlock:tailBlock:"];
 }
 

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -13,7 +13,7 @@
 @class RACDisposable;
 @class RACMulticastConnection;
 @class RACScheduler;
-@class RACSequence;
+@class RACSequence<__covariant ValueType>;
 @class RACSubject;
 @class RACTuple;
 @class RACEvent<__covariant ValueType>;
@@ -525,7 +525,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a sequence which provides values from the signal as they're sent.
 /// Trying to retrieve a value from the sequence which has not yet been sent will
 /// block.
-@property (nonatomic, strong, readonly) RACSequence *sequence;
+@property (nonatomic, strong, readonly) RACSequence<ValueType> *sequence;
 
 /// Creates and returns a multicast connection. This allows you to share a single
 /// subscription to the underlying signal.
@@ -651,7 +651,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which only passes through `error` or `completed` events from
 /// the receiver.
-- (RACSignal<ValueType> *)ignoreValues;
+- (RACSignal *)ignoreValues;
 
 /// Converts each of the receiver's events into a RACEvent object.
 ///


### PR DESCRIPTION
Continues the pattern established with RACSignal into RACSequence by adding `__coviariant ValueType` lightweight generics.