### PR TITLE
Fix bufferWithTime return value

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -137,7 +137,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which sends RACTuples of the buffered values at each
 /// interval on `scheduler`. When the receiver completes, any currently-buffered
 /// values will be sent immediately.
-- (RACSignal<ValueType> *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
+- (RACSignal<RACTuple *> *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
 /// Collects all receiver's `next`s into a NSArray. Nil values will be converted
 /// to NSNull.


### PR DESCRIPTION
Unless buffer's functionality has changed, it should be sending along `RACTuple`s of `ValueType`, not `ValueType` itself.