### PR TITLE
remove the unecessary header guard

### DIFF
--- a/ReactiveObjC/extobjc/metamacros.h
+++ b/ReactiveObjC/extobjc/metamacros.h
@@ -6,9 +6,6 @@
  * Released under the MIT license
  */
 
-#ifndef EXTC_METAMACROS_H
-#define EXTC_METAMACROS_H
-
 /**
  * Executes one or more expressions (which may have a void type, such as a call
  * to a function that returns no value) and always returns true.
@@ -662,5 +659,3 @@ metamacro_if_eq(0, 1)(true)(false)
 #define metamacro_drop18(...) metamacro_drop17(metamacro_tail(__VA_ARGS__))
 #define metamacro_drop19(...) metamacro_drop18(metamacro_tail(__VA_ARGS__))
 #define metamacro_drop20(...) metamacro_drop19(metamacro_tail(__VA_ARGS__))
-
-#endif


### PR DESCRIPTION
It is not necessary to use the header guard because `#import` will ensure that the header is included at most once.
It also causes `metamacro_xxx not found error` when ReactiveObjC is imported by `@import ReactiveObjC`. I don't understand how objc modules work, so I cannot explain why it causes such errors.