### PR TITLE
Don't encourage `-rac_liftSelector:withSignals:` for subscription

### DIFF
--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -534,8 +534,6 @@ subscriptions and disposal:
  * The [RAC()][RAC] or [RACChannelTo()][RACChannelTo] macros can be used to bind
    a signal to a property, instead of performing manual updates when changes
    occur.
- * The [-rac_liftSelector:withSignals:][NSObject+RACLifting] method can be used
-   to automatically invoke a selector when one or more signals fire.
  * Operators like [-takeUntil:][RACSignal+Operations] can be used to
    automatically dispose of a subscription when an event occurs (like a "Cancel"
    button being pressed in the UI).


### PR DESCRIPTION
This guideline encourages the use of `-rac_liftSelector:withSignals:` to
effect implicit subscription. However, the eager subscription that
occurs when that method is called [is regarded as a mistake][0],
and [its use to effect implicit subscription is discouraged][1].

[0]: https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1096#issuecomment-34506990
[1]: https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1096#issuecomment-34842565