### PR TITLE
Add type annotations for NSObject+RACLifting

### DIFF
--- a/ReactiveObjC/NSObject+RACLifting.h
+++ b/ReactiveObjC/NSObject+RACLifting.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Like -rac_liftSelector:withSignals:, but accepts an array instead of
 /// a variadic list of arguments.
-- (RACSignal *)rac_liftSelector:(SEL)selector withSignalsFromArray:(NSArray *)signals;
+- (RACSignal *)rac_liftSelector:(SEL)selector withSignalsFromArray:(NSArray<RACSignal *> *)signals;
 
 /// Like -rac_liftSelector:withSignals:, but accepts a signal sending tuples of
 /// arguments instead of a variadic list of arguments.

--- a/ReactiveObjC/NSObject+RACLifting.h
+++ b/ReactiveObjC/NSObject+RACLifting.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACSignal<__covariant ValueType>;
+@class RACTuple;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Like -rac_liftSelector:withSignals:, but accepts a signal sending tuples of
 /// arguments instead of a variadic list of arguments.
-- (RACSignal *)rac_liftSelector:(SEL)selector withSignalOfArguments:(RACSignal *)arguments;
+- (RACSignal *)rac_liftSelector:(SEL)selector withSignalOfArguments:(RACSignal<RACTuple *> *)arguments;
 
 @end
 


### PR DESCRIPTION
As an example, this allows us to change the following Swift code:

```swift
self.rac_liftSelector(mySelector, withSignalOfArguments: mySignalOfTuples as! RACSignal<AnyObject>)
```

into this:

```swift
self.rac_liftSelector(mySelector, withSignalOfArguments: mySignalOfTuples)
```