### PR TITLE
More type annotations

### DIFF
--- a/ReactiveObjC/RACBehaviorSubject.h
+++ b/ReactiveObjC/RACBehaviorSubject.h
@@ -11,11 +11,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A behavior subject sends the last value it received when it is subscribed to.
-@interface RACBehaviorSubject : RACSubject
+@interface RACBehaviorSubject<__covariant ValueType> : RACSubject
 
 /// Creates a new behavior subject with a default value. If it hasn't received
 /// any values when it gets subscribed to, it sends the default value.
-+ (instancetype)behaviorSubjectWithDefaultValue:(nullable id)value;
++ (instancetype)behaviorSubjectWithDefaultValue:(nullable ValueType)value;
 
 @end
 

--- a/ReactiveObjC/RACBehaviorSubject.m
+++ b/ReactiveObjC/RACBehaviorSubject.m
@@ -10,10 +10,10 @@
 #import "RACDisposable.h"
 #import "RACScheduler+Private.h"
 
-@interface RACBehaviorSubject ()
+@interface RACBehaviorSubject<__covariant ValueType> ()
 
 // This property should only be used while synchronized on self.
-@property (nonatomic, strong) id currentValue;
+@property (nonatomic, strong) ValueType currentValue;
 
 @end
 

--- a/ReactiveObjC/RACEmptySignal.h
+++ b/ReactiveObjC/RACEmptySignal.h
@@ -12,6 +12,6 @@
 // subscribers.
 @interface RACEmptySignal : RACSignal
 
-+ (RACSignal *)empty;
++ (instancetype)empty;
 
 @end

--- a/ReactiveObjC/RACEmptySignal.h
+++ b/ReactiveObjC/RACEmptySignal.h
@@ -10,8 +10,8 @@
 
 // A private `RACSignal` subclasses that synchronously sends completed to any
 // subscribers.
-@interface RACEmptySignal : RACSignal
+@interface RACEmptySignal<__covariant ValueType> : RACSignal
 
-+ (instancetype)empty;
++ (RACSignal<ValueType> *)empty;
 
 @end

--- a/ReactiveObjC/RACEmptySignal.m
+++ b/ReactiveObjC/RACEmptySignal.m
@@ -32,7 +32,7 @@
 
 #pragma mark Lifecycle
 
-+ (instancetype)empty {
++ (RACSignal *)empty {
 #ifdef DEBUG
 	// Create multiple instances of this class in DEBUG so users can set custom
 	// names on each.

--- a/ReactiveObjC/RACEmptySignal.m
+++ b/ReactiveObjC/RACEmptySignal.m
@@ -32,7 +32,7 @@
 
 #pragma mark Lifecycle
 
-+ (RACSignal *)empty {
++ (instancetype)empty {
 #ifdef DEBUG
 	// Create multiple instances of this class in DEBUG so users can set custom
 	// names on each.

--- a/ReactiveObjC/RACErrorSignal.h
+++ b/ReactiveObjC/RACErrorSignal.h
@@ -8,8 +8,8 @@
 
 #import "RACSignal.h"
 
-// A private `RACSignal` subclasses that synchronously sends an error to any
-// subscribers.
+// A private `RACSignal` subclass that synchronously sends an error to any
+// subscriber.
 @interface RACErrorSignal : RACSignal
 
 + (RACSignal *)error:(NSError *)error;

--- a/ReactiveObjC/RACMulticastConnection+Private.h
+++ b/ReactiveObjC/RACMulticastConnection+Private.h
@@ -10,8 +10,8 @@
 
 @class RACSubject;
 
-@interface RACMulticastConnection ()
+@interface RACMulticastConnection<__covariant ValueType> ()
 
-- (instancetype)initWithSourceSignal:(RACSignal *)source subject:(RACSubject *)subject;
+- (instancetype)initWithSourceSignal:(RACSignal<ValueType> *)source subject:(RACSubject *)subject;
 
 @end

--- a/ReactiveObjC/RACMulticastConnection.h
+++ b/ReactiveObjC/RACMulticastConnection.h
@@ -25,10 +25,10 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Note that you shouldn't create RACMulticastConnection manually. Instead use
 /// -[RACSignal publish] or -[RACSignal multicast:].
-@interface RACMulticastConnection : NSObject
+@interface RACMulticastConnection<__covariant ValueType> : NSObject
 
 /// The multicasted signal.
-@property (nonatomic, strong, readonly) RACSignal *signal;
+@property (nonatomic, strong, readonly) RACSignal<ValueType> *signal;
 
 /// Connect to the underlying signal by subscribing to it. Calling this multiple
 /// times does nothing but return the existing connection's disposable.
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// multicasted signal.
 ///
 /// Returns the autoconnecting signal.
-- (RACSignal *)autoconnect;
+- (RACSignal<ValueType> *)autoconnect;
 
 @end
 

--- a/ReactiveObjC/RACReturnSignal.h
+++ b/ReactiveObjC/RACReturnSignal.h
@@ -10,8 +10,8 @@
 
 // A private `RACSignal` subclasses that synchronously sends a value to any
 // subscribers, then completes.
-@interface RACReturnSignal : RACSignal
+@interface RACReturnSignal<__covariant ValueType> : RACSignal
 
-+ (RACSignal *)return:(id)value;
++ (RACSignal<ValueType> *)return:(ValueType)value;
 
 @end

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -11,7 +11,7 @@
 
 @class RACCommand;
 @class RACDisposable;
-@class RACMulticastConnection;
+@class RACMulticastConnection<__covariant ValueType>;
 @class RACScheduler;
 @class RACSequence<__covariant ValueType>;
 @class RACSubject;
@@ -529,12 +529,12 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Creates and returns a multicast connection. This allows you to share a single
 /// subscription to the underlying signal.
-- (RACMulticastConnection *)publish;
+- (RACMulticastConnection<ValueType> *)publish;
 
 /// Creates and returns a multicast connection that pushes values into the given
 /// subject. This allows you to share a single subscription to the underlying
 /// signal.
-- (RACMulticastConnection *)multicast:(RACSubject *)subject;
+- (RACMulticastConnection<ValueType> *)multicast:(RACSubject *)subject;
 
 /// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
 /// immediately connects to the resulting RACMulticastConnection.


### PR DESCRIPTION
This pull request adds generics to `RACMulticastConnection`, `RACBehaviorSubject` and type annotations to `RACSignal`'s `+empty` and `+return` methods.

It seems to me that it'd also make sense to add generics to `RACChannelTerminal`, `RACChannel` and `RACSubject`. Thoughts on that?