### PR TITLE
RACSubject generics

### DIFF
--- a/ReactiveObjC/RACBehaviorSubject.h
+++ b/ReactiveObjC/RACBehaviorSubject.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A behavior subject sends the last value it received when it is subscribed to.
-@interface RACBehaviorSubject<__covariant ValueType> : RACSubject
+@interface RACBehaviorSubject<ValueType> : RACSubject<ValueType>
 
 /// Creates a new behavior subject with a default value. If it hasn't received
 /// any values when it gets subscribed to, it sends the default value.

--- a/ReactiveObjC/RACBehaviorSubject.m
+++ b/ReactiveObjC/RACBehaviorSubject.m
@@ -10,7 +10,7 @@
 #import "RACDisposable.h"
 #import "RACScheduler+Private.h"
 
-@interface RACBehaviorSubject<__covariant ValueType> ()
+@interface RACBehaviorSubject<ValueType> ()
 
 // This property should only be used while synchronized on self.
 @property (nonatomic, strong) ValueType currentValue;

--- a/ReactiveObjC/RACEmptySignal.h
+++ b/ReactiveObjC/RACEmptySignal.h
@@ -10,7 +10,7 @@
 
 // A private `RACSignal` subclasses that synchronously sends completed to any
 // subscribers.
-@interface RACEmptySignal<ValueType> : RACSignal<ValueType>
+@interface RACEmptySignal<__covariant ValueType> : RACSignal<ValueType>
 
 + (RACSignal<ValueType> *)empty;
 

--- a/ReactiveObjC/RACEmptySignal.h
+++ b/ReactiveObjC/RACEmptySignal.h
@@ -10,7 +10,7 @@
 
 // A private `RACSignal` subclasses that synchronously sends completed to any
 // subscribers.
-@interface RACEmptySignal<__covariant ValueType> : RACSignal
+@interface RACEmptySignal<ValueType> : RACSignal<ValueType>
 
 + (RACSignal<ValueType> *)empty;
 

--- a/ReactiveObjC/RACMulticastConnection+Private.h
+++ b/ReactiveObjC/RACMulticastConnection+Private.h
@@ -8,7 +8,7 @@
 
 #import "RACMulticastConnection.h"
 
-@class RACSubject;
+@class RACSubject<__covariant ValueType>;
 
 @interface RACMulticastConnection<__covariant ValueType> ()
 

--- a/ReactiveObjC/RACMulticastConnection+Private.h
+++ b/ReactiveObjC/RACMulticastConnection+Private.h
@@ -8,7 +8,7 @@
 
 #import "RACMulticastConnection.h"
 
-@class RACSubject<__covariant ValueType>;
+@class RACSubject;
 
 @interface RACMulticastConnection<__covariant ValueType> ()
 

--- a/ReactiveObjC/RACReplaySubject.h
+++ b/ReactiveObjC/RACReplaySubject.h
@@ -15,7 +15,7 @@ extern const NSUInteger RACReplaySubjectUnlimitedCapacity;
 /// A replay subject saves the values it is sent (up to its defined capacity)
 /// and resends those to new subscribers. It will also replay an error or
 /// completion.
-@interface RACReplaySubject : RACSubject
+@interface RACReplaySubject<ValueType> : RACSubject<ValueType>
 
 /// Creates a new replay subject with the given capacity. A capacity of
 /// RACReplaySubjectUnlimitedCapacity means values are never trimmed.

--- a/ReactiveObjC/RACReturnSignal.h
+++ b/ReactiveObjC/RACReturnSignal.h
@@ -10,7 +10,7 @@
 
 // A private `RACSignal` subclasses that synchronously sends a value to any
 // subscribers, then completes.
-@interface RACReturnSignal<__covariant ValueType> : RACSignal
+@interface RACReturnSignal<ValueType> : RACSignal<ValueType>
 
 + (RACSignal<ValueType> *)return:(ValueType)value;
 

--- a/ReactiveObjC/RACReturnSignal.h
+++ b/ReactiveObjC/RACReturnSignal.h
@@ -10,7 +10,7 @@
 
 // A private `RACSignal` subclasses that synchronously sends a value to any
 // subscribers, then completes.
-@interface RACReturnSignal<ValueType> : RACSignal<ValueType>
+@interface RACReturnSignal<__covariant ValueType> : RACSignal<ValueType>
 
 + (RACSignal<ValueType> *)return:(ValueType)value;
 

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -14,7 +14,7 @@
 @class RACMulticastConnection<__covariant ValueType>;
 @class RACScheduler;
 @class RACSequence<__covariant ValueType>;
-@class RACSubject;
+@class RACSubject<__covariant ValueType>;
 @class RACTuple;
 @class RACEvent<__covariant ValueType>;
 @protocol RACSubscriber;
@@ -534,7 +534,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Creates and returns a multicast connection that pushes values into the given
 /// subject. This allows you to share a single subscription to the underlying
 /// signal.
-- (RACMulticastConnection<ValueType> *)multicast:(RACSubject *)subject;
+- (RACMulticastConnection<ValueType> *)multicast:(RACSubject<ValueType> *)subject;
 
 /// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
 /// immediately connects to the resulting RACMulticastConnection.

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -14,7 +14,7 @@
 @class RACMulticastConnection<__covariant ValueType>;
 @class RACScheduler;
 @class RACSequence<__covariant ValueType>;
-@class RACSubject<__covariant ValueType>;
+@class RACSubject<ValueType>;
 @class RACTuple;
 @class RACEvent<__covariant ValueType>;
 @protocol RACSubscriber;

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// They're most helpful in bridging the non-RAC world to RAC, since they let you
 /// manually control the sending of events.
-@interface RACSubject : RACSignal <RACSubscriber>
+@interface RACSubject<__covariant ValueType> : RACSignal<ValueType> <RACSubscriber>
 
 /// Returns a new subject.
 + (instancetype)subject;

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -21,6 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a new subject.
 + (instancetype)subject;
 
+// Redeclaration of the RACSubscriber method, in order to specify a generic type.
+- (void)sendNext:(nullable ValueType)value;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a new subject.
 + (instancetype)subject;
 
-// Redeclaration of the RACSubscriber method, in order to specify a generic type.
+// Redeclaration of the RACSubscriber method. Made in order to specify a generic type.
 - (void)sendNext:(nullable ValueType)value;
 
 @end

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// They're most helpful in bridging the non-RAC world to RAC, since they let you
 /// manually control the sending of events.
-@interface RACSubject<ValueType> : RACSignal <RACSubscriber>
+@interface RACSubject<ValueType> : RACSignal<ValueType> <RACSubscriber>
 
 /// Returns a new subject.
 + (instancetype)subject;

--- a/ReactiveObjC/RACSubject.h
+++ b/ReactiveObjC/RACSubject.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// They're most helpful in bridging the non-RAC world to RAC, since they let you
 /// manually control the sending of events.
-@interface RACSubject<__covariant ValueType> : RACSignal<ValueType> <RACSubscriber>
+@interface RACSubject<ValueType> : RACSignal <RACSubscriber>
 
 /// Returns a new subject.
 + (instancetype)subject;


### PR DESCRIPTION
Lightweight generics for RACSubject, giving us some autocompletion and helping us bridge with Swift.

Solves #58.

Unfortunately I couldn't find a nice way of extending the generics to `sendNext:`, for the reason that ObjC protocols don't support generics (`sendNext:` is declared in `RACSubscriber`).