### PR TITLE
Add warnings to unused signal operator results

### DIFF
--- a/ReactiveObjC.xcodeproj/project.pbxproj
+++ b/ReactiveObjC.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
+		3A17B4A61E8EFDD500C8999E /* RACAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A17B4A71E8EFDD800C8999E /* RACAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A17B4A81E8EFDDA00C8999E /* RACAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3A17B4A91E8EFDDF00C8999E /* RACAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		57A4D1B21BA13D7A00F7D4B1 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D037646A19EDA41200A782A9 /* RACCompoundDisposableProvider.d */; };
 		57A4D1B31BA13D7A00F7D4B1 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D03764A319EDA41200A782A9 /* RACSignalProvider.d */; };
 		57A4D1C11BA13D7A00F7D4B1 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037666819EDA57100A782A9 /* EXTRuntimeExtensions.m */; };
@@ -760,6 +764,7 @@
 /* Begin PBXFileReference section */
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RACAnnotations.h; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -1178,7 +1183,6 @@
 		D04725EC19E49ED7006002AA /* ReactiveObjC */ = {
 			isa = PBXGroup;
 			children = (
-				D04725EF19E49ED7006002AA /* ReactiveObjC.h */,
 				D037666519EDA57100A782A9 /* extobjc */,
 				314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */,
 				314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */,
@@ -1232,6 +1236,7 @@
 				D037645919EDA41200A782A9 /* NSURLConnection+RACSupport.m */,
 				D037645A19EDA41200A782A9 /* NSUserDefaults+RACSupport.h */,
 				D037645B19EDA41200A782A9 /* NSUserDefaults+RACSupport.m */,
+				3A17B4A51E8EFDCD00C8999E /* RACAnnotations.h */,
 				D037645C19EDA41200A782A9 /* RACArraySequence.h */,
 				D037645D19EDA41200A782A9 /* RACArraySequence.m */,
 				D037646019EDA41200A782A9 /* RACBehaviorSubject.h */,
@@ -1332,6 +1337,8 @@
 				D03764BF19EDA41200A782A9 /* RACUnit.m */,
 				D03764C019EDA41200A782A9 /* RACValueTransformer.h */,
 				D03764C119EDA41200A782A9 /* RACValueTransformer.m */,
+				D04725EF19E49ED7006002AA /* ReactiveObjC.h */,
+				D04725ED19E49ED7006002AA /* Supporting Files */,
 				D03764C219EDA41200A782A9 /* UIActionSheet+RACSignalSupport.h */,
 				D03764C319EDA41200A782A9 /* UIActionSheet+RACSignalSupport.m */,
 				D03764C419EDA41200A782A9 /* UIAlertView+RACSignalSupport.h */,
@@ -1370,7 +1377,6 @@
 				D03764E519EDA41200A782A9 /* UITextField+RACSignalSupport.m */,
 				D03764E619EDA41200A782A9 /* UITextView+RACSignalSupport.h */,
 				D03764E719EDA41200A782A9 /* UITextView+RACSignalSupport.m */,
-				D04725ED19E49ED7006002AA /* Supporting Files */,
 			);
 			path = ReactiveObjC;
 			sourceTree = "<group>";
@@ -1591,6 +1597,7 @@
 				57A4D2331BA13D7A00F7D4B1 /* RACSubject.h in Headers */,
 				57A4D2341BA13D7A00F7D4B1 /* RACSubscriber.h in Headers */,
 				57A4D2351BA13D7A00F7D4B1 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
+				3A17B4A91E8EFDDF00C8999E /* RACAnnotations.h in Headers */,
 				57A4D2361BA13D7A00F7D4B1 /* RACTargetQueueScheduler.h in Headers */,
 				57A4D2371BA13D7A00F7D4B1 /* RACTestScheduler.h in Headers */,
 				57A4D2381BA13D7A00F7D4B1 /* RACTuple.h in Headers */,
@@ -1627,6 +1634,7 @@
 				A9B315EA1B3940AB0001CB9C /* RACBehaviorSubject.h in Headers */,
 				A9B315EC1B3940AB0001CB9C /* RACChannel.h in Headers */,
 				A9B315ED1B3940AC0001CB9C /* RACCommand.h in Headers */,
+				3A17B4A81E8EFDDA00C8999E /* RACAnnotations.h in Headers */,
 				A9B315EE1B3940AC0001CB9C /* RACCompoundDisposable.h in Headers */,
 				A9B315F01B3940AC0001CB9C /* RACDisposable.h in Headers */,
 				A9B315F71B3940AC0001CB9C /* RACEvent.h in Headers */,
@@ -1678,6 +1686,7 @@
 				BEBDD6E81CDC292F009A75A9 /* RACDelegateProxy.h in Headers */,
 				D037652419EDA41200A782A9 /* NSObject+RACPropertySubscribing.h in Headers */,
 				D037650019EDA41200A782A9 /* NSFileHandle+RACSupport.h in Headers */,
+				3A17B4A61E8EFDD500C8999E /* RACAnnotations.h in Headers */,
 				D037653019EDA41200A782A9 /* NSSet+RACSequenceAdditions.h in Headers */,
 				D037654019EDA41200A782A9 /* NSText+RACSignalSupport.h in Headers */,
 				D03765E019EDA41200A782A9 /* RACStream.h in Headers */,
@@ -1744,6 +1753,7 @@
 				D037663519EDA41200A782A9 /* UIDatePicker+RACSignalSupport.h in Headers */,
 				D037667419EDA57100A782A9 /* metamacros.h in Headers */,
 				D03764FD19EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.h in Headers */,
+				3A17B4A71E8EFDD800C8999E /* RACAnnotations.h in Headers */,
 				D037652119EDA41200A782A9 /* NSObject+RACLifting.h in Headers */,
 				D037665919EDA41200A782A9 /* UITableViewHeaderFooterView+RACSignalSupport.h in Headers */,
 				D037656519EDA41200A782A9 /* RACCompoundDisposable.h in Headers */,

--- a/ReactiveObjC/RACAnnotations.h
+++ b/ReactiveObjC/RACAnnotations.h
@@ -1,0 +1,11 @@
+//
+//  RACAnnotations.h
+//  ReactiveObjC
+//
+//  Created by Eric Horacek on 3/31/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+#ifndef RAC_WARN_UNUSED_RESULT
+#define RAC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#endif

--- a/ReactiveObjC/RACMulticastConnection.h
+++ b/ReactiveObjC/RACMulticastConnection.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "RACAnnotations.h"
 
 @class RACDisposable;
 @class RACSignal<__covariant ValueType>;
@@ -45,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// multicasted signal.
 ///
 /// Returns the autoconnecting signal.
-- (RACSignal<ValueType> *)autoconnect;
+- (RACSignal<ValueType> *)autoconnect RAC_WARN_UNUSED_RESULT;
 
 @end
 

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -36,15 +36,15 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Do the given block on `next`. This should be used to inject side effects into
 /// the signal.
-- (RACSignal<ValueType> *)doNext:(void (^)(ValueType _Nullable x))block;
+- (RACSignal<ValueType> *)doNext:(void (^)(ValueType _Nullable x))block RAC_WARN_UNUSED_RESULT;
 
 /// Do the given block on `error`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal<ValueType> *)doError:(void (^)(NSError * _Nonnull error))block;
+- (RACSignal<ValueType> *)doError:(void (^)(NSError * _Nonnull error))block RAC_WARN_UNUSED_RESULT;
 
 /// Do the given block on `completed`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal<ValueType> *)doCompleted:(void (^)(void))block;
+- (RACSignal<ValueType> *)doCompleted:(void (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Sends `next`s only if we don't receive another `next` in `interval` seconds.
 ///
@@ -58,7 +58,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends throttled and delayed `next` events. Completion
 /// and errors are always forwarded immediately.
-- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval;
+- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval RAC_WARN_UNUSED_RESULT;
 
 /// Throttles `next`s for which `predicate` returns YES.
 ///
@@ -83,7 +83,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends `next` events, throttled when `predicate`
 /// returns YES. Completion and errors are always forwarded immediately.
-- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id _Nullable next))predicate;
+- (RACSignal<ValueType> *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id _Nullable next))predicate RAC_WARN_UNUSED_RESULT;
 
 /// Forwards `next` and `completed` events after delaying for `interval` seconds
 /// on the current scheduler (on which the events were delivered).
@@ -93,10 +93,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends delayed `next` and `completed` events. Errors
 /// are always forwarded immediately.
-- (RACSignal<ValueType> *)delay:(NSTimeInterval)interval;
+- (RACSignal<ValueType> *)delay:(NSTimeInterval)interval RAC_WARN_UNUSED_RESULT;
 
 /// Resubscribes when the signal completes.
-- (RACSignal<ValueType> *)repeat;
+- (RACSignal<ValueType> *)repeat RAC_WARN_UNUSED_RESULT;
 
 /// Executes the given block each time a subscription is created.
 ///
@@ -122,10 +122,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that passes through all events of the receiver, plus
 /// introduces side effects which occur prior to any subscription side effects
 /// of the receiver.
-- (RACSignal<ValueType> *)initially:(void (^)(void))block;
+- (RACSignal<ValueType> *)initially:(void (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Executes the given block when the signal completes or errors.
-- (RACSignal<ValueType> *)finally:(void (^)(void))block;
+- (RACSignal<ValueType> *)finally:(void (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Divides the receiver's `next`s into buffers which deliver every `interval`
 /// seconds.
@@ -147,10 +147,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends a single NSArray when the receiver completes
 /// successfully.
-- (RACSignal<NSArray<ValueType> *> *)collect;
+- (RACSignal<NSArray<ValueType> *> *)collect RAC_WARN_UNUSED_RESULT;
 
 /// Takes the last `count` `next`s after the receiving signal completes.
-- (RACSignal<ValueType> *)takeLast:(NSUInteger)count;
+- (RACSignal<ValueType> *)takeLast:(NSUInteger)count RAC_WARN_UNUSED_RESULT;
 
 /// Combines the latest values from the receiver and the given signal into
 /// RACTuples, once both have sent at least one `next`.
@@ -162,7 +162,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends RACTuples of the combined values, forwards any
 /// `error` events, and completes when both input signals complete.
-- (RACSignal<RACTuple *> *)combineLatestWith:(RACSignal *)signal;
+- (RACSignal<RACTuple *> *)combineLatestWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 /// Combines the latest values from the given signals into RACTuples, once all
 /// the signals have sent at least one `next`.
@@ -175,7 +175,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends RACTuples of the combined values, forwards any
 /// `error` events, and completes when all input signals complete.
-+ (RACSignal<RACTuple *> *)combineLatest:(id<NSFastEnumeration>)signals;
++ (RACSignal<RACTuple *> *)combineLatest:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
 
 /// Combines signals using +combineLatest:, then reduces the resulting tuples
 /// into a single value using -reduceEach:.
@@ -196,18 +196,18 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends the results from each invocation of
 /// `reduceBlock`.
-+ (RACSignal<ValueType> *)combineLatest:(id<NSFastEnumeration>)signals reduce:(ValueType _Nullable (^)())reduceBlock;
++ (RACSignal<ValueType> *)combineLatest:(id<NSFastEnumeration>)signals reduce:(ValueType _Nullable (^)())reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Merges the receiver and the given signal with `+merge:` and returns the
 /// resulting signal.
-- (RACSignal *)merge:(RACSignal *)signal;
+- (RACSignal *)merge:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 /// Sends the latest `next` from any of the signals.
 ///
 /// Returns a signal that passes through values from each of the given signals,
 /// and sends `completed` when all of them complete. If any signal sends an error,
 /// the returned signal sends `error` immediately.
-+ (RACSignal<ValueType> *)merge:(id<NSFastEnumeration>)signals;
++ (RACSignal<ValueType> *)merge:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
 
 /// Merges the signals sent by the receiver into a flattened signal, but only
 /// subscribes to `maxConcurrent` number of signals at a time. New signals are
@@ -222,7 +222,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// maxConcurrent - the maximum number of signals to subscribe to at a
 ///                 time. If 0, it subscribes to an unlimited number of
 ///                 signals.
-- (RACSignal *)flatten:(NSUInteger)maxConcurrent;
+- (RACSignal *)flatten:(NSUInteger)maxConcurrent RAC_WARN_UNUSED_RESULT;
 
 /// Ignores all `next`s from the receiver, waits for the receiver to complete,
 /// then subscribes to a new signal.
@@ -233,10 +233,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which will pass through the events of the signal created in
 /// `block`. If the receiver errors out, the returned signal will error as well.
-- (RACSignal *)then:(RACSignal * (^)(void))block;
+- (RACSignal *)then:(RACSignal * (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Concats the inner signals of a signal of signals.
-- (RACSignal *)concat;
+- (RACSignal *)concat RAC_WARN_UNUSED_RESULT;
 
 /// Aggregates the `next` values of the receiver into a single combined value.
 ///
@@ -261,7 +261,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that will send the aggregated value when the receiver
 /// completes, then itself complete. If the receiver never sends any values,
 /// `start` will be sent instead.
-- (RACSignal *)aggregateWithStart:(id)start reduce:(id (^)(id running, id next))reduceBlock;
+- (RACSignal *)aggregateWithStart:(id)start reduce:(id (^)(id running, id next))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Aggregates the `next` values of the receiver into a single combined value.
 /// This is indexed version of -aggregateWithStart:reduce:.
@@ -276,7 +276,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that will send the aggregated value when the receiver
 /// completes, then itself complete. If the receiver never sends any values,
 /// `start` will be sent instead.
-- (RACSignal *)aggregateWithStart:(id)start reduceWithIndex:(id (^)(id running, id next, NSUInteger index))reduceBlock;
+- (RACSignal *)aggregateWithStart:(id)start reduceWithIndex:(id (^)(id running, id next, NSUInteger index))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Aggregates the `next` values of the receiver into a single combined value.
 ///
@@ -292,7 +292,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that will send the aggregated value when the receiver
 /// completes, then itself complete. If the receiver never sends any values,
 /// the return value of `startFactory` will be sent instead.
-- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory reduce:(id (^)(id running, id next))reduceBlock;
+- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory reduce:(id (^)(id running, id next))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Invokes -setKeyPath:onObject:nilValue: with `nil` for the nil value.
 ///
@@ -340,7 +340,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal that sends the current date/time every `interval` on
 /// `scheduler`.
-+ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
++ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler RAC_WARN_UNUSED_RESULT;
 
 /// Sends NSDate.date at intervals of at least `interval` seconds, up to
 /// approximately `interval` + `leeway` seconds.
@@ -358,14 +358,14 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal that sends the current date/time at intervals of at least
 /// `interval seconds` up to approximately `interval` + `leeway` seconds on
 /// `scheduler`.
-+ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway;
++ (RACSignal<NSDate *> *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway RAC_WARN_UNUSED_RESULT;
 
 /// Takes `next`s until the `signalTrigger` sends `next` or `completed`.
 ///
 /// Returns a signal which passes through all events from the receiver until
 /// `signalTrigger` sends `next` or `completed`, at which point the returned signal
 /// will send `completed`.
-- (RACSignal<ValueType> *)takeUntil:(RACSignal *)signalTrigger;
+- (RACSignal<ValueType> *)takeUntil:(RACSignal *)signalTrigger RAC_WARN_UNUSED_RESULT;
 
 /// Takes `next`s until the `replacement` sends an event.
 ///
@@ -376,13 +376,13 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// until `replacement` sends an event, at which point the returned signal will
 /// send that event and switch to passing through events from `replacement`
 /// instead, regardless of whether the receiver has sent events already.
-- (RACSignal *)takeUntilReplacement:(RACSignal *)replacement;
+- (RACSignal *)takeUntilReplacement:(RACSignal *)replacement RAC_WARN_UNUSED_RESULT;
 
 /// Subscribes to the returned signal when an error occurs.
-- (RACSignal *)catch:(RACSignal * (^)(NSError * _Nonnull error))catchBlock;
+- (RACSignal *)catch:(RACSignal * (^)(NSError * _Nonnull error))catchBlock RAC_WARN_UNUSED_RESULT;
 
 /// Subscribes to the given signal when an error occurs.
-- (RACSignal *)catchTo:(RACSignal *)signal;
+- (RACSignal *)catchTo:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal that will either immediately send the return value of
 /// `tryBlock` and complete, or error using the `NSError` passed out from the
@@ -397,7 +397,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///   [RACSignal try:^(NSError **error) {
 ///       return [NSJSONSerialization JSONObjectWithData:someJSONData options:0 error:error];
 ///   }];
-+ (RACSignal<ValueType> *)try:(nullable ValueType (^)(NSError **errorPtr))tryBlock;
++ (RACSignal<ValueType> *)try:(nullable ValueType (^)(NSError **errorPtr))tryBlock RAC_WARN_UNUSED_RESULT;
 
 /// Runs `tryBlock` against each of the receiver's values, passing values
 /// until `tryBlock` returns NO, or the receiver completes.
@@ -417,7 +417,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which passes through all the values of the receiver. If
 /// `tryBlock` fails for any value, the returned signal will error using the
 /// `NSError` passed out from the block.
-- (RACSignal<ValueType> *)try:(BOOL (^)(id _Nullable value, NSError **errorPtr))tryBlock;
+- (RACSignal<ValueType> *)try:(BOOL (^)(id _Nullable value, NSError **errorPtr))tryBlock RAC_WARN_UNUSED_RESULT;
 
 /// Runs `mapBlock` against each of the receiver's values, mapping values until
 /// `mapBlock` returns nil, or the receiver completes.
@@ -437,7 +437,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which transforms all the values of the receiver. If
 /// `mapBlock` returns nil for any value, the returned signal will error using
 /// the `NSError` passed out from the block.
-- (RACSignal *)tryMap:(id (^)(id _Nullable value, NSError **errorPtr))mapBlock;
+- (RACSignal *)tryMap:(id (^)(id _Nullable value, NSError **errorPtr))mapBlock RAC_WARN_UNUSED_RESULT;
 
 /// Returns the first `next`. Note that this is a blocking call.
 - (nullable ValueType)first;
@@ -464,7 +464,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Defers creation of a signal until the signal's actually subscribed to.
 ///
 /// This can be used to effectively turn a hot signal into a cold signal.
-+ (RACSignal<ValueType> *)defer:(RACSignal<ValueType> * (^)(void))block;
++ (RACSignal<ValueType> *)defer:(RACSignal<ValueType> * (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Every time the receiver sends a new RACSignal, subscribes and sends `next`s and
 /// `error`s only for that signal.
@@ -474,7 +474,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which passes through `next`s and `error`s from the latest
 /// signal sent by the receiver, and sends `completed` when both the receiver and
 /// the last sent signal complete.
-- (RACSignal *)switchToLatest;
+- (RACSignal *)switchToLatest RAC_WARN_UNUSED_RESULT;
 
 /// Switches between the signals in `cases` as well as `defaultSignal` based on
 /// the latest value sent by `signal`.
@@ -493,7 +493,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// the signals in `cases` or `defaultSignal`, and sends `completed` when both
 /// `signal` and the last used signal complete. If no `defaultSignal` is given,
 /// an unmatched `next` will result in an error on the returned signal.
-+ (RACSignal<ValueType> *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(nullable RACSignal *)defaultSignal;
++ (RACSignal<ValueType> *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(nullable RACSignal *)defaultSignal RAC_WARN_UNUSED_RESULT;
 
 /// Switches between `trueSignal` and `falseSignal` based on the latest value
 /// sent by `boolSignal`.
@@ -508,7 +508,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which passes through `next`s and `error`s from `trueSignal`
 /// and/or `falseSignal`, and sends `completed` when both `boolSignal` and the
 /// last switched signal complete.
-+ (RACSignal<ValueType> *)if:(RACSignal<NSNumber *> *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal;
++ (RACSignal<ValueType> *)if:(RACSignal<NSNumber *> *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal RAC_WARN_UNUSED_RESULT;
 
 /// Adds every `next` to an array. Nils are represented by NSNulls. Note that
 /// this is a blocking call.
@@ -530,12 +530,12 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Creates and returns a multicast connection. This allows you to share a single
 /// subscription to the underlying signal.
-- (RACMulticastConnection<ValueType> *)publish;
+- (RACMulticastConnection<ValueType> *)publish RAC_WARN_UNUSED_RESULT;
 
 /// Creates and returns a multicast connection that pushes values into the given
 /// subject. This allows you to share a single subscription to the underlying
 /// signal.
-- (RACMulticastConnection<ValueType> *)multicast:(RACSubject *)subject;
+- (RACMulticastConnection<ValueType> *)multicast:(RACSubject *)subject RAC_WARN_UNUSED_RESULT;
 
 /// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
 /// immediately connects to the resulting RACMulticastConnection.
@@ -570,7 +570,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal that passes through the receiver's events, until the stream
 /// finishes or times out, at which point an error will be sent on `scheduler`.
-- (RACSignal<ValueType> *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler RAC_WARN_UNUSED_RESULT;
 
 /// Creates and returns a signal that delivers its events on the given scheduler.
 /// Any side effects of the receiver will still be performed on the original
@@ -580,7 +580,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// thread, but you want to handle its events elsewhere.
 ///
 /// This corresponds to the `ObserveOn` method in Rx.
-- (RACSignal<ValueType> *)deliverOn:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)deliverOn:(RACScheduler *)scheduler RAC_WARN_UNUSED_RESULT;
 
 /// Creates and returns a signal that executes its side effects and delivers its
 /// events on the given scheduler.
@@ -588,7 +588,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Use of this operator should be avoided whenever possible, because the
 /// receiver's side effects may not be safe to run on another thread. If you just
 /// want to receive the signal's events on `scheduler`, use -deliverOn: instead.
-- (RACSignal<ValueType> *)subscribeOn:(RACScheduler *)scheduler;
+- (RACSignal<ValueType> *)subscribeOn:(RACScheduler *)scheduler RAC_WARN_UNUSED_RESULT;
 
 /// Creates and returns a signal that delivers its events on the main thread.
 /// If events are already being sent on the main thread, they may be passed on
@@ -602,42 +602,42 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// This can be used when a signal will cause UI updates, to avoid potential
 /// flicker caused by delayed delivery of events, such as the first event from
 /// a RACObserve at view instantiation.
-- (RACSignal<ValueType> *)deliverOnMainThread;
+- (RACSignal<ValueType> *)deliverOnMainThread RAC_WARN_UNUSED_RESULT;
 
 /// Groups each received object into a group, as determined by calling `keyBlock`
 /// with that object. The object sent is transformed by calling `transformBlock`
 /// with the object. If `transformBlock` is nil, it sends the original object.
 ///
 /// The returned signal is a signal of RACGroupedSignal.
-- (RACSignal<RACGroupedSignal *> *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock transform:(nullable id _Nullable (^)(id _Nullable object))transformBlock;
+- (RACSignal<RACGroupedSignal *> *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock transform:(nullable id _Nullable (^)(id _Nullable object))transformBlock  RAC_WARN_UNUSED_RESULT;
 
 /// Calls -[RACSignal groupBy:keyBlock transform:nil].
-- (RACSignal<RACGroupedSignal *> *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock;
+- (RACSignal<RACGroupedSignal *> *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock  RAC_WARN_UNUSED_RESULT;
 
 /// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
 /// objects.
-- (RACSignal<NSNumber *> *)any;
+- (RACSignal<NSNumber *> *)any RAC_WARN_UNUSED_RESULT;
 
 /// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
 /// objects that pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal<NSNumber *> *)any:(BOOL (^)(id _Nullable object))predicateBlock;
+- (RACSignal<NSNumber *> *)any:(BOOL (^)(id _Nullable object))predicateBlock RAC_WARN_UNUSED_RESULT;
 
 /// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
 /// signal sends pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal<NSNumber *> *)all:(BOOL (^)(id _Nullable object))predicateBlock;
+- (RACSignal<NSNumber *> *)all:(BOOL (^)(id _Nullable object))predicateBlock RAC_WARN_UNUSED_RESULT;
 
 /// Resubscribes to the receiving signal if an error occurs, up until it has
 /// retried the given number of times.
 ///
 /// retryCount - if 0, it keeps retrying until it completes.
-- (RACSignal<ValueType> *)retry:(NSInteger)retryCount;
+- (RACSignal<ValueType> *)retry:(NSInteger)retryCount RAC_WARN_UNUSED_RESULT;
 
 /// Resubscribes to the receiving signal if an error occurs.
-- (RACSignal<ValueType> *)retry;
+- (RACSignal<ValueType> *)retry RAC_WARN_UNUSED_RESULT;
 
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
@@ -646,45 +646,45 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// sampler - The signal that controls when the latest value from the receiver
 ///           is sent. Cannot be nil.
-- (RACSignal<ValueType> *)sample:(RACSignal *)sampler;
+- (RACSignal<ValueType> *)sample:(RACSignal *)sampler RAC_WARN_UNUSED_RESULT;
 
 /// Ignores all `next`s from the receiver.
 ///
 /// Returns a signal which only passes through `error` or `completed` events from
 /// the receiver.
-- (RACSignal *)ignoreValues;
+- (RACSignal *)ignoreValues RAC_WARN_UNUSED_RESULT;
 
 /// Converts each of the receiver's events into a RACEvent object.
 ///
 /// Returns a signal which sends the receiver's events as RACEvents, and
 /// completes after the receiver sends `completed` or `error`.
-- (RACSignal<RACEvent<ValueType> *> *)materialize;
+- (RACSignal<RACEvent<ValueType> *> *)materialize RAC_WARN_UNUSED_RESULT;
 
 /// Converts each RACEvent in the receiver back into "real" RACSignal events.
 ///
 /// Returns a signal which sends `next` for each value RACEvent, `error` for each
 /// error RACEvent, and `completed` for each completed RACEvent.
-- (RACSignal *)dematerialize;
+- (RACSignal *)dematerialize RAC_WARN_UNUSED_RESULT;
 
 /// Inverts each NSNumber-wrapped BOOL sent by the receiver. It will assert if
 /// the receiver sends anything other than NSNumbers.
 ///
 /// Returns a signal of inverted NSNumber-wrapped BOOLs.
-- (RACSignal<NSNumber *> *)not;
+- (RACSignal<NSNumber *> *)not RAC_WARN_UNUSED_RESULT;
 
 /// Performs a boolean AND on all of the RACTuple of NSNumbers in sent by the receiver.
 ///
 /// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
 ///
 /// Returns a signal that applies AND to each NSNumber in the tuple.
-- (RACSignal<NSNumber *> *)and;
+- (RACSignal<NSNumber *> *)and RAC_WARN_UNUSED_RESULT;
 
 /// Performs a boolean OR on all of the RACTuple of NSNumbers in sent by the receiver.
 ///
 /// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
 /// 
 /// Returns a signal that applies OR to each NSNumber in the tuple.
-- (RACSignal<NSNumber *> *)or;
+- (RACSignal<NSNumber *> *)or RAC_WARN_UNUSED_RESULT;
 
 /// Sends the result of calling the block with arguments as packed in each RACTuple
 /// sent by the receiver.
@@ -705,7 +705,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal of the result of applying the first element of each tuple
 /// to the remaining elements.
-- (RACSignal *)reduceApply;
+- (RACSignal *)reduceApply RAC_WARN_UNUSED_RESULT;
 
 @end
 

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "RACAnnotations.h"
 #import "RACStream.h"
 
 @class RACDisposable;
@@ -46,13 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// subscribes. Any side effects within the block will thus execute once for each
 /// subscription, not necessarily on one thread, and possibly even
 /// simultaneously!
-+ (RACSignal<ValueType> *)createSignal:(RACDisposable * _Nullable (^)(id<RACSubscriber> subscriber))didSubscribe;
++ (RACSignal<ValueType> *)createSignal:(RACDisposable * _Nullable (^)(id<RACSubscriber> subscriber))didSubscribe RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal that immediately sends the given error.
-+ (RACSignal<ValueType> *)error:(nullable NSError *)error;
++ (RACSignal<ValueType> *)error:(nullable NSError *)error RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal that never completes.
-+ (RACSignal<ValueType> *)never;
++ (RACSignal<ValueType> *)never RAC_WARN_UNUSED_RESULT;
 
 /// Immediately schedules the given block on the given scheduler. The block is
 /// given a subscriber to which it can send events.
@@ -82,17 +83,17 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns a signal which will pass through the events sent to the subscriber
 /// given to `block` and replay any missed events to new subscribers.
-+ (RACSignal<ValueType> *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
++ (RACSignal<ValueType> *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block RAC_WARN_UNUSED_RESULT;
 
 @end
 
 @interface RACSignal<__covariant ValueType> (RACStream)
 
 /// Returns a signal that immediately sends the given value and then completes.
-+ (RACSignal<ValueType> *)return:(nullable ValueType)value;
++ (RACSignal<ValueType> *)return:(nullable ValueType)value RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal that immediately completes.
-+ (RACSignal<ValueType> *)empty;
++ (RACSignal<ValueType> *)empty RAC_WARN_UNUSED_RESULT;
 
 /// A block which accepts a value from a RACSignal and returns a new signal.
 ///
@@ -111,10 +112,10 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal which represents the combined result of all lazy
 /// applications of `block`.
-- (RACSignal *)bind:(RACSignalBindBlock (^)(void))block;
+- (RACSignal *)bind:(RACSignalBindBlock (^)(void))block RAC_WARN_UNUSED_RESULT;
 
 /// Subscribes to `signal` when the source signal completes.
-- (RACSignal *)concat:(RACSignal *)signal;
+- (RACSignal *)concat:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 /// Zips the values in the receiver with those of the given signal to create
 /// RACTuples.
@@ -127,7 +128,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 /// Returns a new signal of RACTuples, representing the combined values of the
 /// two signals. Any error from one of the original signals will be forwarded on
 /// the returned signal.
-- (RACSignal *)zipWith:(RACSignal *)signal;
+- (RACSignal *)zipWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 @end
 
@@ -168,7 +169,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal which represents the combined signals resulting from
 /// mapping `block`.
-- (RACSignal *)flattenMap:(__kindof RACSignal * _Nullable (^)(ValueType _Nullable value))block;
+- (RACSignal *)flattenMap:(__kindof RACSignal * _Nullable (^)(ValueType _Nullable value))block RAC_WARN_UNUSED_RESULT;
 
 /// Flattens a signal of signals.
 ///
@@ -176,27 +177,27 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a signal consisting of the combined signals obtained from the
 /// receiver.
-- (RACSignal *)flatten;
+- (RACSignal *)flatten RAC_WARN_UNUSED_RESULT;
 
 /// Maps `block` across the values in the receiver.
 ///
 /// This corresponds to the `Select` method in Rx.
 ///
 /// Returns a new signal with the mapped values.
-- (RACSignal *)map:(id _Nullable (^)(ValueType _Nullable value))block;
+- (RACSignal *)map:(id _Nullable (^)(ValueType _Nullable value))block RAC_WARN_UNUSED_RESULT;
 
 /// Replaces each value in the receiver with the given object.
 ///
 /// Returns a new signal which includes the given object once for each value in
 /// the receiver.
-- (RACSignal *)mapReplace:(nullable id)object;
+- (RACSignal *)mapReplace:(nullable id)object RAC_WARN_UNUSED_RESULT;
 
 /// Filters out values in the receiver that don't pass the given test.
 ///
 /// This corresponds to the `Where` method in Rx.
 ///
 /// Returns a new signal with only those values that passed.
-- (RACSignal<ValueType> *)filter:(BOOL (^)(ValueType _Nullable value))block;
+- (RACSignal<ValueType> *)filter:(BOOL (^)(ValueType _Nullable value))block RAC_WARN_UNUSED_RESULT;
 
 /// Filters out values in the receiver that equal (via -isEqual:) the provided
 /// value.
@@ -205,7 +206,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal containing only the values which did not compare equal
 /// to `value`.
-- (RACSignal<ValueType> *)ignore:(nullable ValueType)value;
+- (RACSignal<ValueType> *)ignore:(nullable ValueType)value RAC_WARN_UNUSED_RESULT;
 
 /// Unpacks each RACTuple in the receiver and maps the values to a new value.
 ///
@@ -215,23 +216,23 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///               return value must be an object. This argument cannot be nil.
 ///
 /// Returns a new signal of reduced tuple values.
-- (RACSignal *)reduceEach:(id _Nullable (^)())reduceBlock;
+- (RACSignal *)reduceEach:(id _Nullable (^)())reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal consisting of `value`, followed by the values in the
 /// receiver.
-- (RACSignal<ValueType> *)startWith:(nullable ValueType)value;
+- (RACSignal<ValueType> *)startWith:(nullable ValueType)value RAC_WARN_UNUSED_RESULT;
 
 /// Skips the first `skipCount` values in the receiver.
 ///
 /// Returns the receiver after skipping the first `skipCount` values. If
 /// `skipCount` is greater than the number of values in the signal, an empty
 /// signal is returned.
-- (RACSignal<ValueType> *)skip:(NSUInteger)skipCount;
+- (RACSignal<ValueType> *)skip:(NSUInteger)skipCount RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal of the first `count` values in the receiver. If `count` is
 /// greater than or equal to the number of values in the signal, a signal
 /// equivalent to the receiver is returned.
-- (RACSignal<ValueType> *)take:(NSUInteger)count;
+- (RACSignal<ValueType> *)take:(NSUInteger)count RAC_WARN_UNUSED_RESULT;
 
 /// Zips the values in the given signals to create RACTuples.
 ///
@@ -243,7 +244,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal containing RACTuples of the zipped values from the
 /// signals.
-+ (RACSignal<ValueType> *)zip:(id<NSFastEnumeration>)signals;
++ (RACSignal<ValueType> *)zip:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
 
 /// Zips signals using +zip:, then reduces the resulting tuples into a single
 /// value using -reduceEach:
@@ -265,10 +266,10 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal containing the results from each invocation of
 /// `reduceBlock`.
-+ (RACSignal<ValueType> *)zip:(id<NSFastEnumeration>)signals reduce:(id _Nullable (^)())reduceBlock;
++ (RACSignal<ValueType> *)zip:(id<NSFastEnumeration>)signals reduce:(id _Nullable (^)())reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal obtained by concatenating `signals` in order.
-+ (RACSignal<ValueType> *)concat:(id<NSFastEnumeration>)signals;
++ (RACSignal<ValueType> *)concat:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
 
 /// Combines values in the receiver from left to right using the given block.
 ///
@@ -298,7 +299,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal that consists of each application of `reduceBlock`. If
 /// the receiver is empty, an empty signal is returned.
-- (RACSignal *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next))reduceBlock;
+- (RACSignal *)scanWithStart:(nullable id)startingValue reduce:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Combines values in the receiver from left to right using the given block
 /// which also takes zero-based index of the values.
@@ -312,7 +313,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal that consists of each application of `reduceBlock`. If
 /// the receiver is empty, an empty signal is returned.
-- (RACSignal *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next, NSUInteger index))reduceBlock;
+- (RACSignal *)scanWithStart:(nullable id)startingValue reduceWithIndex:(id _Nullable (^)(id _Nullable running, ValueType _Nullable next, NSUInteger index))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Combines each previous and current value into one object.
 ///
@@ -337,39 +338,39 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal consisting of the return values from each application of
 /// `reduceBlock`.
-- (RACSignal *)combinePreviousWithStart:(nullable ValueType)start reduce:(id _Nullable (^)(ValueType _Nullable previous, ValueType _Nullable current))reduceBlock;
+- (RACSignal *)combinePreviousWithStart:(nullable ValueType)start reduce:(id _Nullable (^)(ValueType _Nullable previous, ValueType _Nullable current))reduceBlock RAC_WARN_UNUSED_RESULT;
 
 /// Takes values until the given block returns `YES`.
 ///
 /// Returns a signal of the initial values in the receiver that fail `predicate`.
 /// If `predicate` never returns `YES`, a signal equivalent to the receiver is
 /// returned.
-- (RACSignal<ValueType> *)takeUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate;
+- (RACSignal<ValueType> *)takeUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate RAC_WARN_UNUSED_RESULT;
 
 /// Takes values until the given block returns `NO`.
 ///
 /// Returns a signal of the initial values in the receiver that pass `predicate`.
 /// If `predicate` never returns `NO`, a signal equivalent to the receiver is
 /// returned.
-- (RACSignal<ValueType> *)takeWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate;
+- (RACSignal<ValueType> *)takeWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate RAC_WARN_UNUSED_RESULT;
 
 /// Skips values until the given block returns `YES`.
 ///
 /// Returns a signal containing the values of the receiver that follow any
 /// initial values failing `predicate`. If `predicate` never returns `YES`,
 /// an empty signal is returned.
-- (RACSignal<ValueType> *)skipUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate;
+- (RACSignal<ValueType> *)skipUntilBlock:(BOOL (^)(ValueType _Nullable x))predicate RAC_WARN_UNUSED_RESULT;
 
 /// Skips values until the given block returns `NO`.
 ///
 /// Returns a signal containing the values of the receiver that follow any
 /// initial values passing `predicate`. If `predicate` never returns `NO`, an
 /// empty signal is returned.
-- (RACSignal<ValueType> *)skipWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate;
+- (RACSignal<ValueType> *)skipWhileBlock:(BOOL (^)(ValueType _Nullable x))predicate RAC_WARN_UNUSED_RESULT;
 
 /// Returns a signal of values for which -isEqual: returns NO when compared to the
 /// previous value.
-- (RACSignal<ValueType> *)distinctUntilChanged;
+- (RACSignal<ValueType> *)distinctUntilChanged RAC_WARN_UNUSED_RESULT;
 
 @end
 
@@ -426,16 +427,16 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 @interface RACSignal<__covariant ValueType> (Debugging)
 
 /// Logs all events that the receiver sends.
-- (RACSignal<ValueType> *)logAll;
+- (RACSignal<ValueType> *)logAll RAC_WARN_UNUSED_RESULT;
 
 /// Logs each `next` that the receiver sends.
-- (RACSignal<ValueType> *)logNext;
+- (RACSignal<ValueType> *)logNext RAC_WARN_UNUSED_RESULT;
 
 /// Logs any error that the receiver sends.
-- (RACSignal<ValueType> *)logError;
+- (RACSignal<ValueType> *)logError RAC_WARN_UNUSED_RESULT;
 
 /// Logs any `completed` event that the receiver sends.
-- (RACSignal<ValueType> *)logCompleted;
+- (RACSignal<ValueType> *)logCompleted RAC_WARN_UNUSED_RESULT;
 
 @end
 


### PR DESCRIPTION
One of the most common sources of confusion with developers that are new to the concepts of FRP is that subscriptions are required to drive values through signal operators. New developers frequently spend a long time trying to figure out why code such as:

```
[signal logAll];
```

is not performing any logging side-effects. To help with this confusion, I’ve added unused result warnings to side-effectless signal operators to help raise a warning to newcomers that operators are side-effectless.

This change will also help with catching typos that would otherwise compile without warning, such as forgetting to type `return` before a signal chain when you are attempting to write an early return in a method.