### PR TITLE
Add generic typed tuples

### DIFF
--- a/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
+++ b/ReactiveObjC/NSDictionary+RACSequenceAdditions.h
@@ -9,17 +9,16 @@
 #import <Foundation/Foundation.h>
 
 @class RACSequence<__covariant ValueType>;
-@class RACTuple;
+@class RACTwoTuple<__covariant First, __covariant Second>;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDictionary<__covariant KeyType, __covariant ObjectType> (RACSequenceAdditions)
 
-/// Creates and returns a sequence of RACTuple key/value pairs. The key will be
-/// the first element in the tuple, and the value will be the second.
+/// Creates and returns a sequence of key/value tuples.
 ///
 /// Mutating the receiver will not affect the sequence after it's been created.
-@property (nonatomic, copy, readonly) RACSequence<RACTuple *> *rac_sequence;
+@property (nonatomic, copy, readonly) RACSequence<RACTwoTuple<KeyType, ObjectType> *> *rac_sequence;
 
 /// Creates and returns a sequence corresponding to the keys in the receiver.
 ///

--- a/ReactiveObjC/NSObject+RACPropertySubscribing.h
+++ b/ReactiveObjC/NSObject+RACPropertySubscribing.h
@@ -65,6 +65,7 @@
 #endif
 
 @class RACDisposable;
+@class RACTwoTuple<__covariant First, __covariant Second>;
 @class RACSignal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -95,9 +96,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a signal that sends tuples containing the current value at the key
 /// path and the change dictionary for each KVO callback.
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
-- (RACSignal *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(__weak NSObject *)observer;
+- (RACSignal<RACTwoTuple<id, NSDictionary *> *> *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(__weak NSObject *)observer;
 #else
-- (RACSignal *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer;
+- (RACSignal<RACTwoTuple<id, NSDictionary *> *> *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer;
 #endif
 
 @end

--- a/ReactiveObjC/NSObject+RACSelectorSignal.h
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+@class RACTuple;
 @class RACSignal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -54,7 +55,7 @@ extern const NSInteger RACSelectorSignalErrorMethodSwizzlingRace;
 /// will be sent synchronously from the thread that invoked the method. If
 /// a runtime call fails, the signal will send an error in the
 /// RACSelectorSignalErrorDomain.
-- (RACSignal *)rac_signalForSelector:(SEL)selector;
+- (RACSignal<RACTuple *> *)rac_signalForSelector:(SEL)selector;
 
 /// Behaves like -rac_signalForSelector:, but if the selector is not yet
 /// implemented on the receiver, its method signature is looked up within
@@ -76,7 +77,7 @@ extern const NSInteger RACSelectorSignalErrorMethodSwizzlingRace;
 /// Returns a signal which will send a tuple of arguments on each invocation of
 /// the selector, or an error in RACSelectorSignalErrorDomain if a runtime
 /// call fails.
-- (RACSignal *)rac_signalForSelector:(SEL)selector fromProtocol:(Protocol *)protocol;
+- (RACSignal<RACTuple *> *)rac_signalForSelector:(SEL)selector fromProtocol:(Protocol *)protocol;
 
 @end
 

--- a/ReactiveObjC/NSURLConnection+RACSupport.h
+++ b/ReactiveObjC/NSURLConnection+RACSupport.h
@@ -8,22 +8,22 @@
 
 #import <Foundation/Foundation.h>
 
-@class RACTuple;
+@class RACTwoTuple<__covariant First, __covariant Second>;
 @class RACSignal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSURLConnection (RACSupport)
 
-// Lazily loads data for the given request in the background.
-//
-// request - The URL request to load. This must not be nil.
-//
-// Returns a signal which will begin loading the request upon each subscription,
-// then send a `RACTuple` of the received `NSURLResponse` and downloaded
-// `NSData`, and complete on a background thread. If any errors occur, the
-// returned signal will error out.
-+ (RACSignal<RACTuple *> *)rac_sendAsynchronousRequest:(NSURLRequest *)request;
+/// Lazily loads data for the given request in the background.
+///
+/// request - The URL request to load. This must not be nil.
+///
+/// Returns a signal which will begin loading the request upon each subscription,
+/// then send a tuple of the received response and downloaded data, and complete
+/// on a background thread. If any errors occur, the returned signal will error
+/// out.
++ (RACSignal<RACTwoTuple<NSURLResponse *, NSData *> *> *)rac_sendAsynchronousRequest:(NSURLRequest *)request;
 
 @end
 

--- a/ReactiveObjC/RACSequence.h
+++ b/ReactiveObjC/RACSequence.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "RACStream.h"
 
+@class RACTuple;
 @class RACScheduler;
 @class RACSignal<__covariant ValueType>;
 
@@ -190,7 +191,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(ValueType _Nullable valu
 /// Returns a new sequence of RACTuples, representing the combined values of the
 /// two sequences. Any error from one of the original sequence will be forwarded
 /// on the returned sequence.
-- (RACSequence *)zipWith:(RACSequence *)sequence;
+- (RACSequence<RACTuple *> *)zipWith:(RACSequence *)sequence;
 
 @end
 
@@ -286,7 +287,7 @@ typedef RACSequence * _Nullable (^RACSequenceBindBlock)(ValueType _Nullable valu
 ///
 /// Returns a new sequence containing RACTuples of the zipped values from the
 /// sequences.
-+ (RACSequence<ValueType> *)zip:(id<NSFastEnumeration>)sequence;
++ (RACSequence<RACTuple *> *)zip:(id<NSFastEnumeration>)sequence;
 
 /// Zips sequences using +zip:, then reduces the resulting tuples into a single
 /// value using -reduceEach:

--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -16,6 +16,7 @@
 @class RACSequence<__covariant ValueType>;
 @class RACSubject<ValueType>;
 @class RACTuple;
+@class RACTwoTuple<__covariant First, __covariant Second>;
 @class RACEvent<__covariant ValueType>;
 @class RACGroupedSignal;
 @protocol RACSubscriber;
@@ -153,7 +154,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal<ValueType> *)takeLast:(NSUInteger)count RAC_WARN_UNUSED_RESULT;
 
 /// Combines the latest values from the receiver and the given signal into
-/// RACTuples, once both have sent at least one `next`.
+/// 2-tuples, once both have sent at least one `next`.
 ///
 /// Any additional `next`s will result in a new RACTuple with the latest values
 /// from both signals.
@@ -162,7 +163,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends RACTuples of the combined values, forwards any
 /// `error` events, and completes when both input signals complete.
-- (RACSignal<RACTuple *> *)combineLatestWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
+- (RACSignal<RACTwoTuple<ValueType, id> *> *)combineLatestWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 /// Combines the latest values from the given signals into RACTuples, once all
 /// the signals have sent at least one `next`.

--- a/ReactiveObjC/RACSignal.h
+++ b/ReactiveObjC/RACSignal.h
@@ -13,6 +13,8 @@
 @class RACDisposable;
 @class RACScheduler;
 @class RACSubject;
+@class RACTuple;
+@class RACTwoTuple<__covariant First, __covariant Second>;
 @protocol RACSubscriber;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -128,7 +130,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 /// Returns a new signal of RACTuples, representing the combined values of the
 /// two signals. Any error from one of the original signals will be forwarded on
 /// the returned signal.
-- (RACSignal *)zipWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
+- (RACSignal<RACTwoTuple<ValueType, id> *> *)zipWith:(RACSignal *)signal RAC_WARN_UNUSED_RESULT;
 
 @end
 
@@ -244,7 +246,7 @@ typedef RACSignal * _Nullable (^RACSignalBindBlock)(ValueType _Nullable value, B
 ///
 /// Returns a new signal containing RACTuples of the zipped values from the
 /// signals.
-+ (RACSignal<ValueType> *)zip:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
++ (RACSignal<RACTuple *> *)zip:(id<NSFastEnumeration>)signals RAC_WARN_UNUSED_RESULT;
 
 /// Zips signals using +zip:, then reduces the resulting tuples into a single
 /// value using -reduceEach:

--- a/ReactiveObjC/RACTuple.h
+++ b/ReactiveObjC/RACTuple.h
@@ -43,6 +43,10 @@
 #define RACTupleUnpack(...) \
         RACTupleUnpack_(__VA_ARGS__)
 
+@class RACThreeTuple<__covariant First, __covariant Second, __covariant Third>;
+@class RACFourTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth>;
+@class RACFiveTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth, __covariant Fifth>;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// A sentinel object that represents nils in the tuple.
@@ -94,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// obj - The object to add to the tuple. This argument may be nil.
 ///
 /// Returns a new tuple.
-- (instancetype)tupleByAddingObject:(nullable id)obj;
+- (__kindof RACTuple *)tupleByAddingObject:(nullable id)obj;
 
 @end
 
@@ -111,14 +115,83 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id)objectAtIndexedSubscript:(NSUInteger)idx;
 @end
 
+/// A tuple with exactly two generic values.
+@interface RACTwoTuple<__covariant First, __covariant Second> : RACTuple
+
++ (instancetype)tupleWithObjects:(id)object, ... __attribute((unavailable("Use pack:: instead.")));
+
+- (RACThreeTuple<First, Second, id> *)tupleByAddingObject:(nullable id)obj;
+
+/// Creates a new tuple with the given values.
++ (RACTwoTuple<First, Second> *)pack:(First)first :(Second)second;
+
+@property (nonatomic, readonly, nullable) First first;
+@property (nonatomic, readonly, nullable) Second second;
+
+@end
+
+/// A tuple with exactly three generic values.
+@interface RACThreeTuple<__covariant First, __covariant Second, __covariant Third> : RACTuple
+
++ (instancetype)tupleWithObjects:(id)object, ... __attribute((unavailable("Use pack::: instead.")));
+
+- (RACFourTuple<First, Second, Third, id> *)tupleByAddingObject:(nullable id)obj;
+
+/// Creates a new tuple with the given values.
++ (instancetype)pack:(nullable First)first :(nullable Second)second :(nullable Third)third;
+
+@property (nonatomic, readonly, nullable) First first;
+@property (nonatomic, readonly, nullable) Second second;
+@property (nonatomic, readonly, nullable) Third third;
+
+@end
+
+/// A tuple with exactly four generic values.
+@interface RACFourTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth> : RACTuple
+
++ (instancetype)tupleWithObjects:(id)object, ... __attribute((unavailable("Use pack:::: instead.")));
+
+- (RACFiveTuple<First, Second, Third, Fourth, id> *)tupleByAddingObject:(nullable id)obj;
+
+/// Creates a new tuple with the given values.
++ (instancetype)pack:(nullable First)first :(nullable Second)second :(nullable Third)third :(nullable Fourth)fourth;
+
+@property (nonatomic, readonly, nullable) First first;
+@property (nonatomic, readonly, nullable) Second second;
+@property (nonatomic, readonly, nullable) Third third;
+@property (nonatomic, readonly, nullable) Fourth fourth;
+
+@end
+
+/// A tuple with exactly five generic values.
+@interface RACFiveTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth, __covariant Fifth> : RACTuple
+
++ (instancetype)tupleWithObjects:(id)object, ... __attribute((unavailable("Use pack::::: instead.")));
+
+/// Creates a new tuple with the given values.
++ (instancetype)pack:(nullable First)first :(nullable Second)second :(nullable Third)third :(nullable Fourth)fourth :(nullable Fifth)fifth;
+
+@property (nonatomic, readonly, nullable) First first;
+@property (nonatomic, readonly, nullable) Second second;
+@property (nonatomic, readonly, nullable) Third third;
+@property (nonatomic, readonly, nullable) Fourth fourth;
+@property (nonatomic, readonly, nullable) Fifth fifth;
+
+@end
+
 /// This and everything below is for internal use only.
 ///
 /// See RACTuplePack() and RACTupleUnpack() instead.
 #define RACTuplePack_(...) \
-    ([RACTuple tupleWithObjectsFromArray:@[ metamacro_foreach(RACTuplePack_object_or_ractuplenil,, __VA_ARGS__) ]])
+    ([RACTuplePack_class_name(__VA_ARGS__) tupleWithObjectsFromArray:@[ metamacro_foreach(RACTuplePack_object_or_ractuplenil,, __VA_ARGS__) ]])
 
 #define RACTuplePack_object_or_ractuplenil(INDEX, ARG) \
     (ARG) ?: RACTupleNil.tupleNil,
+
+/// Returns the class that should be used to create a tuple with the provided
+/// variadic arguments to RACTuplePack_(). Supports up to 20 arguments.
+#define RACTuplePack_class_name(...) \
+        metamacro_at(20, __VA_ARGS__, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACFiveTuple, RACFourTuple, RACThreeTuple, RACTwoTuple, RACTuple)
 
 #define RACTupleUnpack_(...) \
     metamacro_foreach(RACTupleUnpack_decl,, __VA_ARGS__) \

--- a/ReactiveObjC/RACTuple.h
+++ b/ReactiveObjC/RACTuple.h
@@ -43,6 +43,7 @@
 #define RACTupleUnpack(...) \
         RACTupleUnpack_(__VA_ARGS__)
 
+@class RACTwoTuple<__covariant First, __covariant Second>;
 @class RACThreeTuple<__covariant First, __covariant Second, __covariant Third>;
 @class RACFourTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth>;
 @class RACFiveTuple<__covariant First, __covariant Second, __covariant Third, __covariant Fourth, __covariant Fifth>;
@@ -113,6 +114,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the object at that index or nil if the number of objects is less
 /// than the index.
 - (nullable id)objectAtIndexedSubscript:(NSUInteger)idx;
+@end
+
+/// A tuple with exactly one generic value.
+@interface RACOneTuple<__covariant First> : RACTuple
+
++ (instancetype)tupleWithObjects:(id)object, ... __attribute((unavailable("Use pack: instead.")));
+
+- (RACTwoTuple<First, id> *)tupleByAddingObject:(nullable id)obj;
+
+/// Creates a new tuple with the given values.
++ (RACOneTuple<First> *)pack:(First)first;
+
+@property (nonatomic, readonly, nullable) First first;
+
 @end
 
 /// A tuple with exactly two generic values.
@@ -191,7 +206,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the class that should be used to create a tuple with the provided
 /// variadic arguments to RACTuplePack_(). Supports up to 20 arguments.
 #define RACTuplePack_class_name(...) \
-        metamacro_at(20, __VA_ARGS__, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACFiveTuple, RACFourTuple, RACThreeTuple, RACTwoTuple, RACTuple)
+        metamacro_at(20, __VA_ARGS__, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACTuple, RACFiveTuple, RACFourTuple, RACThreeTuple, RACTwoTuple, RACOneTuple)
 
 #define RACTupleUnpack_(...) \
     metamacro_foreach(RACTupleUnpack_decl,, __VA_ARGS__) \

--- a/ReactiveObjC/RACTuple.h
+++ b/ReactiveObjC/RACTuple.h
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (RACThreeTuple<First, Second, id> *)tupleByAddingObject:(nullable id)obj;
 
-/// Creates a new tuple with the given values.
+/// Creates a new tuple with the given value.
 + (RACTwoTuple<First, Second> *)pack:(First)first :(Second)second;
 
 @property (nonatomic, readonly, nullable) First first;

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -237,7 +237,7 @@
 }
 
 + (instancetype)pack:(id)first {
-    return [self tupleWithObjectsFromArray:@[
+	return [self tupleWithObjectsFromArray:@[
 		first ?: RACTupleNil.tupleNil,
 	]];
 }
@@ -272,7 +272,7 @@
 }
 
 + (instancetype)pack:(id)first :(id)second {
-    return [self tupleWithObjectsFromArray:@[
+	return [self tupleWithObjectsFromArray:@[
 		first ?: RACTupleNil.tupleNil,
 		second ?: RACTupleNil.tupleNil,
 	]];
@@ -309,7 +309,7 @@
 }
 
 + (instancetype)pack:(id)first :(id)second :(id)third {
-    return [self tupleWithObjectsFromArray:@[
+	return [self tupleWithObjectsFromArray:@[
 		first ?: RACTupleNil.tupleNil,
 		second ?: RACTupleNil.tupleNil,
 		third ?: RACTupleNil.tupleNil,
@@ -348,7 +348,7 @@
 }
 
 + (instancetype)pack:(id)first :(id)second :(id)third :(id)fourth {
-    return [self tupleWithObjectsFromArray:@[
+	return [self tupleWithObjectsFromArray:@[
 		first ?: RACTupleNil.tupleNil,
 		second ?: RACTupleNil.tupleNil,
 		third ?: RACTupleNil.tupleNil,
@@ -384,7 +384,7 @@
 }
 
 + (instancetype)pack:(id)first :(id)second :(id)third :(id)fourth :(id)fifth {
-    return [self tupleWithObjectsFromArray:@[
+	return [self tupleWithObjectsFromArray:@[
 		first ?: RACTupleNil.tupleNil,
 		second ?: RACTupleNil.tupleNil,
 		third ?: RACTupleNil.tupleNil,

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -220,6 +220,41 @@
 
 @end
 
+@implementation RACOneTuple
+
+- (instancetype)init {
+	return [self initWithBackingArray:@[ RACTupleNil.tupleNil ]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
+	NSParameterAssert(backingArray.count == 1);
+	return [super initWithBackingArray:backingArray];
+}
+
+- (RACTwoTuple *)tupleByAddingObject:(id)obj {
+	NSArray *newArray = [self.backingArray arrayByAddingObject:obj ?: RACTupleNil.tupleNil];
+	return [RACTwoTuple tupleWithObjectsFromArray:newArray];
+}
+
++ (instancetype)pack:(id)first {
+    return [self tupleWithObjectsFromArray:@[
+		first ?: RACTupleNil.tupleNil,
+	]];
+}
+
+- (BOOL)isEqual:(RACTuple *)object {
+	if (object == self) return YES;
+
+	// We consider a RACTuple with an identical backing array as equal.
+	if (![object isKindOfClass:RACTuple.class]) return NO;
+	
+	return [self.backingArray isEqual:object.backingArray];
+}
+
+@dynamic first;
+
+@end
+
 @implementation RACTwoTuple
 
 - (instancetype)init {

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -42,6 +42,7 @@
 
 
 @interface RACTuple ()
+- (instancetype)initWithBackingArray:(NSArray *)backingArray NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, strong) NSArray *backingArray;
 @end
 
@@ -49,9 +50,13 @@
 @implementation RACTuple
 
 - (instancetype)init {
+	return [self initWithBackingArray:@[]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
 	self = [super init];
 	
-	self.backingArray = [NSArray array];
+	_backingArray = [backingArray copy];
 	
 	return self;
 }
@@ -92,14 +97,14 @@
 - (instancetype)initWithCoder:(NSCoder *)coder {
 	self = [self init];
 	
-	self.backingArray = [coder decodeObjectForKey:@keypath(self.backingArray)];
+	_backingArray = [coder decodeObjectForKey:@keypath(self.backingArray)];
+
 	return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
 	if (self.backingArray != nil) [coder encodeObject:self.backingArray forKey:@keypath(self.backingArray)];
 }
-
 
 #pragma mark API
 
@@ -108,25 +113,19 @@
 }
 
 + (instancetype)tupleWithObjectsFromArray:(NSArray *)array convertNullsToNils:(BOOL)convert {
-	RACTuple *tuple = [[self alloc] init];
-	
-	if (convert) {
-		NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:array.count];
-		for (id object in array) {
-			[newArray addObject:(object == NSNull.null ? RACTupleNil.tupleNil : object)];
-		}
-		
-		tuple.backingArray = newArray;
-	} else {
-		tuple.backingArray = [array copy];
+	if (!convert) {
+		return [[self alloc] initWithBackingArray:array];
 	}
-	
-	return tuple;
+
+	NSMutableArray *newArray = [NSMutableArray arrayWithCapacity:array.count];
+	for (id object in array) {
+		[newArray addObject:(object == NSNull.null ? RACTupleNil.tupleNil : object)];
+	}
+
+	return [[self alloc] initWithBackingArray:newArray];
 }
 
 + (instancetype)tupleWithObjects:(id)object, ... {
-	RACTuple *tuple = [[self alloc] init];
-
 	va_list args;
 	va_start(args, object);
 
@@ -138,8 +137,7 @@
 	va_end(args);
 
 	if (count == 0) {
-		tuple.backingArray = @[];
-		return tuple;
+		return [[self alloc] init];
 	}
 	
 	NSMutableArray *objects = [[NSMutableArray alloc] initWithCapacity:count];
@@ -150,9 +148,8 @@
 	}
 
 	va_end(args);
-	
-	tuple.backingArray = objects;
-	return tuple;
+
+	return [[self alloc] initWithBackingArray:objects];
 }
 
 - (id)objectAtIndex:(NSUInteger)index {
@@ -223,6 +220,160 @@
 
 @end
 
+@implementation RACTwoTuple
+
+- (instancetype)init {
+	return [self initWithBackingArray:@[ RACTupleNil.tupleNil, RACTupleNil.tupleNil ]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
+	NSParameterAssert(backingArray.count == 2);
+	return [super initWithBackingArray:backingArray];
+}
+
+- (RACThreeTuple *)tupleByAddingObject:(id)obj {
+	NSArray *newArray = [self.backingArray arrayByAddingObject:obj ?: RACTupleNil.tupleNil];
+	return [RACThreeTuple tupleWithObjectsFromArray:newArray];
+}
+
++ (instancetype)pack:(id)first :(id)second {
+    return [self tupleWithObjectsFromArray:@[
+		first ?: RACTupleNil.tupleNil,
+		second ?: RACTupleNil.tupleNil,
+	]];
+}
+
+- (BOOL)isEqual:(RACTuple *)object {
+	if (object == self) return YES;
+
+	// We consider a RACTuple with an identical backing array as equal.
+	if (![object isKindOfClass:RACTuple.class]) return NO;
+	
+	return [self.backingArray isEqual:object.backingArray];
+}
+
+@dynamic first;
+@dynamic second;
+
+@end
+
+@implementation RACThreeTuple
+
+- (instancetype)init {
+	return [super initWithBackingArray:@[ RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil ]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
+	NSParameterAssert(backingArray.count == 3);
+	return [super initWithBackingArray:backingArray];
+}
+
+- (RACFourTuple *)tupleByAddingObject:(id)obj {
+	NSArray *newArray = [self.backingArray arrayByAddingObject:obj ?: RACTupleNil.tupleNil];
+	return [RACFourTuple tupleWithObjectsFromArray:newArray];
+}
+
++ (instancetype)pack:(id)first :(id)second :(id)third {
+    return [self tupleWithObjectsFromArray:@[
+		first ?: RACTupleNil.tupleNil,
+		second ?: RACTupleNil.tupleNil,
+		third ?: RACTupleNil.tupleNil,
+	]];
+}
+
+- (BOOL)isEqual:(RACTuple *)object {
+	if (object == self) return YES;
+
+	// We consider a RACTuple with an identical backing array as equal.
+	if (![object isKindOfClass:RACTuple.class]) return NO;
+	
+	return [self.backingArray isEqual:object.backingArray];
+}
+
+@dynamic first;
+@dynamic second;
+@dynamic third;
+
+@end
+
+@implementation RACFourTuple
+
+- (instancetype)init {
+	return [self initWithBackingArray:@[ RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil ]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
+	NSParameterAssert(backingArray.count == 4);
+	return [super initWithBackingArray:backingArray];
+}
+
+- (RACFiveTuple *)tupleByAddingObject:(id)obj {
+	NSArray *newArray = [self.backingArray arrayByAddingObject:obj ?: RACTupleNil.tupleNil];
+	return [RACFiveTuple tupleWithObjectsFromArray:newArray];
+}
+
++ (instancetype)pack:(id)first :(id)second :(id)third :(id)fourth {
+    return [self tupleWithObjectsFromArray:@[
+		first ?: RACTupleNil.tupleNil,
+		second ?: RACTupleNil.tupleNil,
+		third ?: RACTupleNil.tupleNil,
+		fourth ?: RACTupleNil.tupleNil,
+	]];
+}
+
+- (BOOL)isEqual:(RACTuple *)object {
+	if (object == self) return YES;
+
+	// We consider a RACTuple with an identical backing array as equal.
+	if (![object isKindOfClass:RACTuple.class]) return NO;
+	
+	return [self.backingArray isEqual:object.backingArray];
+}
+
+@dynamic first;
+@dynamic second;
+@dynamic third;
+@dynamic fourth;
+
+@end
+
+@implementation RACFiveTuple
+
+- (instancetype)init {
+	return [self initWithBackingArray:@[ RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil, RACTupleNil.tupleNil ]];
+}
+
+- (instancetype)initWithBackingArray:(NSArray *)backingArray {
+	NSParameterAssert(backingArray.count == 5);
+	return [super initWithBackingArray:backingArray];
+}
+
++ (instancetype)pack:(id)first :(id)second :(id)third :(id)fourth :(id)fifth {
+    return [self tupleWithObjectsFromArray:@[
+		first ?: RACTupleNil.tupleNil,
+		second ?: RACTupleNil.tupleNil,
+		third ?: RACTupleNil.tupleNil,
+		fourth ?: RACTupleNil.tupleNil,
+		fifth ?: RACTupleNil.tupleNil,
+	]];
+}
+
+- (BOOL)isEqual:(RACTuple *)object {
+	if (object == self) return YES;
+
+	// We consider a RACTuple with an identical backing array as equal.
+	if (![object isKindOfClass:RACTuple.class]) return NO;
+	
+	return [self.backingArray isEqual:object.backingArray];
+}
+
+@dynamic first;
+@dynamic second;
+@dynamic third;
+@dynamic fourth;
+@dynamic fifth;
+
+@end
 
 @implementation RACTupleUnpackingTrampoline
 

--- a/ReactiveObjC/RACTuple.m
+++ b/ReactiveObjC/RACTuple.m
@@ -42,8 +42,11 @@
 
 
 @interface RACTuple ()
+
 - (instancetype)initWithBackingArray:(NSArray *)backingArray NS_DESIGNATED_INITIALIZER;
-@property (nonatomic, strong) NSArray *backingArray;
+
+@property (nonatomic, readonly) NSArray *backingArray;
+
 @end
 
 
@@ -76,13 +79,11 @@
 	return self.backingArray.hash;
 }
 
-
 #pragma mark NSFastEnumeration
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained [])buffer count:(NSUInteger)len {
 	return [self.backingArray countByEnumeratingWithState:state objects:buffer count:len];
 }
-
 
 #pragma mark NSCopying
 
@@ -90,7 +91,6 @@
 	// we're immutable, bitches!
 	return self;
 }
-
 
 #pragma mark NSCoding
 

--- a/ReactiveObjCTests/RACPropertySignalExamples.m
+++ b/ReactiveObjCTests/RACPropertySignalExamples.m
@@ -111,7 +111,7 @@ QuickConfigurationBegin(RACPropertySignalExampleGroups)
 			setupBlock(testObject, @keypath(testObject.integerValue), @42, subject);
 
 			__block BOOL setNilValueForKeyInvoked = NO;
-			[[testObject rac_signalForSelector:@selector(setNilValueForKey:)] subscribeNext:^(NSString *key) {
+			[[testObject rac_signalForSelector:@selector(setNilValueForKey:)] subscribeNext:^(RACTuple *arguments) {
 				setNilValueForKeyInvoked = YES;
 			}];
 
@@ -130,7 +130,7 @@ QuickConfigurationBegin(RACPropertySignalExampleGroups)
 			testObject.catchSetNilValueForKey = YES;
 
 			__block BOOL setNilValueForKeyInvoked = NO;
-			[[testObject rac_signalForSelector:@selector(setNilValueForKey:)] subscribeNext:^(NSString *key) {
+			[[testObject rac_signalForSelector:@selector(setNilValueForKey:)] subscribeNext:^(RACTuple *arguments) {
 				setNilValueForKeyInvoked = YES;
 			}];
 

--- a/ReactiveObjCTests/RACTupleSpec.m
+++ b/ReactiveObjCTests/RACTupleSpec.m
@@ -120,4 +120,93 @@ qck_describe(@"-tupleByAddingObject:", ^{
 	});
 });
 
+qck_describe(@"RACTuple subclasses", ^{
+	qck_describe(@"equality to RACTuple", ^{
+		qck_context(@"RACTwoTuple", ^{
+			qck_it(@"should be equal", ^{
+				RACTwoTuple *tupleSubclass = [RACTwoTuple pack:@"foo" :@"bar"];
+				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo", @"bar" ]];
+				expect(tupleSubclass).to(equal(tuple));
+				expect(tuple).to(equal(tupleSubclass));
+			});
+		});
+
+		qck_context(@"RACThreeTuple", ^{
+			qck_it(@"should be equal", ^{
+				RACThreeTuple *tupleSubclass = [RACThreeTuple pack:@"foo" :@"bar" :@"buzz" ];
+				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo", @"bar", @"buzz" ]];
+				expect(tupleSubclass).to(equal(tuple));
+				expect(tuple).to(equal(tupleSubclass));
+			});
+		});
+
+		qck_context(@"RACFourTuple", ^{
+			qck_it(@"should be equal", ^{
+				RACFourTuple *tupleSubclass = [RACFourTuple pack:@"foo" :@"bar" :@"buzz" :@"fizz"];
+				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo", @"bar", @"buzz", @"fizz" ]];
+				expect(tupleSubclass).to(equal(tuple));
+				expect(tuple).to(equal(tupleSubclass));
+			});
+		});
+
+		qck_context(@"RACFiveTuple", ^{
+			qck_it(@"should be equal", ^{
+				RACFiveTuple *tupleSubclass = [RACFiveTuple pack:@"foo" :@"bar" :@"buzz" :@"fizz" :@"bizz"];
+				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo", @"bar", @"buzz", @"fizz", @"bizz" ]];
+				expect(tupleSubclass).to(equal(tuple));
+				expect(tuple).to(equal(tupleSubclass));
+			});
+		});
+	});
+
+	qck_describe(@"RACTuplePack", ^{
+		qck_context(@"RACTwoTuple", ^{
+			qck_it(@"should be produced by packing", ^{
+				expect(RACTuplePack(@"foo", @"bar")).to(beAnInstanceOf(RACTwoTuple.class));
+			});
+		});
+
+		qck_context(@"RACThreeTuple", ^{
+			qck_it(@"should be produced by packing", ^{
+				expect(RACTuplePack(@"foo", @"bar", @"buzz")).to(beAnInstanceOf(RACThreeTuple.class));
+			});
+		});
+
+		qck_context(@"RACFourTuple", ^{
+			qck_it(@"should be produced by packing", ^{
+				expect(RACTuplePack(@"foo", @"bar", @"buzz", @"fizz")).to(beAnInstanceOf(RACFourTuple.class));
+			});
+		});
+
+		qck_context(@"RACFiveTuple", ^{
+			qck_it(@"should be produced by packing", ^{
+				expect(RACTuplePack(@"foo", @"bar", @"buzz", @"fizz", @"bizz")).to(beAnInstanceOf(RACFiveTuple.class));
+			});
+		});
+	});
+
+	qck_describe(@"-tupleByAddingObject:", ^{
+		qck_context(@"RACTwoTuple", ^{
+			qck_it(@"should produce a RACThreeTuple", ^{
+				RACThreeTuple *tuple = [RACTuplePack(@"foo", @"bar") tupleByAddingObject:@"buzz"];
+				expect(tuple).to(beAnInstanceOf(RACThreeTuple.class));
+			});
+		});
+
+		qck_context(@"RACThreeTuple", ^{
+			qck_it(@"should produce a RACFourTuple", ^{
+				RACFourTuple *tuple = [RACTuplePack(@"foo", @"bar", @"buzz") tupleByAddingObject:@"fizz"];
+				expect(tuple).to(beAnInstanceOf(RACFourTuple.class));
+			});
+		});
+
+		qck_context(@"RACFourTuple", ^{
+			qck_it(@"should produce a RACFiveTuple", ^{
+				RACFiveTuple *tuple = [RACTuplePack(@"foo", @"bar", @"buzz", @"fizz") tupleByAddingObject:@"bizz"];
+				expect(tuple).to(beAnInstanceOf(RACFiveTuple.class));
+			});
+		});
+	});
+});
+
 QuickSpecEnd

--- a/ReactiveObjCTests/RACTupleSpec.m
+++ b/ReactiveObjCTests/RACTupleSpec.m
@@ -122,6 +122,15 @@ qck_describe(@"-tupleByAddingObject:", ^{
 
 qck_describe(@"RACTuple subclasses", ^{
 	qck_describe(@"equality to RACTuple", ^{
+		qck_context(@"RACOneTuple", ^{
+			qck_it(@"should be equal", ^{
+				RACOneTuple *tupleSubclass = [RACOneTuple pack:@"foo"];
+				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo" ]];
+				expect(tupleSubclass).to(equal(tuple));
+				expect(tuple).to(equal(tupleSubclass));
+			});
+		});
+
 		qck_context(@"RACTwoTuple", ^{
 			qck_it(@"should be equal", ^{
 				RACTwoTuple *tupleSubclass = [RACTwoTuple pack:@"foo" :@"bar"];
@@ -133,7 +142,7 @@ qck_describe(@"RACTuple subclasses", ^{
 
 		qck_context(@"RACThreeTuple", ^{
 			qck_it(@"should be equal", ^{
-				RACThreeTuple *tupleSubclass = [RACThreeTuple pack:@"foo" :@"bar" :@"buzz" ];
+				RACThreeTuple *tupleSubclass = [RACThreeTuple pack:@"foo" :@"bar" :@"buzz"];
 				RACTuple *tuple = [RACTuple tupleWithObjectsFromArray:@[ @"foo", @"bar", @"buzz" ]];
 				expect(tupleSubclass).to(equal(tuple));
 				expect(tuple).to(equal(tupleSubclass));
@@ -160,6 +169,12 @@ qck_describe(@"RACTuple subclasses", ^{
 	});
 
 	qck_describe(@"RACTuplePack", ^{
+		qck_context(@"RACOneTuple", ^{
+			qck_it(@"should be produced by packing", ^{
+				expect(RACTuplePack(@"foo")).to(beAnInstanceOf(RACOneTuple.class));
+			});
+		});
+
 		qck_context(@"RACTwoTuple", ^{
 			qck_it(@"should be produced by packing", ^{
 				expect(RACTuplePack(@"foo", @"bar")).to(beAnInstanceOf(RACTwoTuple.class));
@@ -186,6 +201,13 @@ qck_describe(@"RACTuple subclasses", ^{
 	});
 
 	qck_describe(@"-tupleByAddingObject:", ^{
+		qck_context(@"RACOneTuple", ^{
+			qck_it(@"should produce a RACTwoTuple", ^{
+				RACTwoTuple *tuple = [RACTuplePack(@"foo") tupleByAddingObject:@"buzz"];
+				expect(tuple).to(beAnInstanceOf(RACTwoTuple.class));
+			});
+		});
+
 		qck_context(@"RACTwoTuple", ^{
 			qck_it(@"should produce a RACThreeTuple", ^{
 				RACThreeTuple *tuple = [RACTuplePack(@"foo", @"bar") tupleByAddingObject:@"buzz"];


### PR DESCRIPTION
This change adds lightweight generic typed tuples as subclasses of `RACTuple`. This allows tuples to be annotated with the types that they contain, e.g. `RACTwoTuple<NSNumber *, NSString *>`. The supported counts are 1: `RACOneTuple`, 2: `RACTwoTuple`, 3: `RACThreeTuple`, 4: `RACFourTuple`, and 5: `RACFiveTuple`.

To attempt to best satisfy the compiler, `RACTuplePack()` was updated to produce the correct `RACTuple` subclass depending on the number of arguments it is provided. In most cases from now on, if you have a tuple with two elements, you will have a `RACTwoTuple` (and so on). However, you can still produce a regular `RACTuple` with two, three, four, or five elements by using the explicit initialization methods (e.g. `RACTuple tupleWithObjectsFromArray:`).

In cases where you have a `RACTuple` with explicit and differing generic types, it is for the most part unnecessary to use `RACTupleUnpack()` now, since you can get type-safe access to elements by using `tuple.first`, `tuple.second`, etc. However, note that the subscripting methods (e.g. `tuple[0]`) are not possible to annotate with lightweight generic types.

Fixes #57