### PR TITLE
Add lightweight generics to RACChannel and RACChannelTerminal.

### DIFF
--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -9,7 +9,7 @@
 #import "RACSignal.h"
 #import "RACSubscriber.h"
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// on the `followingTerminal`, and received in the model from the
 /// `leadingTerminal`. However, the initial value of the view is not received
 /// from the `leadingTerminal` (only future changes).
-@interface RACChannel<__covariant ValueType> : NSObject
+@interface RACChannel<ValueType> : NSObject
 
 /// The terminal which "leads" the channel, by sending its latest value
 /// immediately to new subscribers of the `followingTerminal`.
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// terminals.
 ///
 /// Do not instantiate this class directly. Create a RACChannel instead.
-@interface RACChannelTerminal<__covariant ValueType> : RACSignal <RACSubscriber>
+@interface RACChannelTerminal<ValueType> : RACSignal<ValueType> <RACSubscriber>
 
 - (instancetype)init __attribute__((unavailable("Instantiate a RACChannel instead")));
 

--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -9,7 +9,7 @@
 #import "RACSignal.h"
 #import "RACSubscriber.h"
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,14 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// on the `followingTerminal`, and received in the model from the
 /// `leadingTerminal`. However, the initial value of the view is not received
 /// from the `leadingTerminal` (only future changes).
-@interface RACChannel : NSObject
+@interface RACChannel<__covariant ValueType> : NSObject
 
 /// The terminal which "leads" the channel, by sending its latest value
 /// immediately to new subscribers of the `followingTerminal`.
 ///
 /// New subscribers to this terminal will not receive a starting value, but will
 /// receive all future values that are sent to the `followingTerminal`.
-@property (nonatomic, strong, readonly) RACChannelTerminal *leadingTerminal;
+@property (nonatomic, strong, readonly) RACChannelTerminal<ValueType> *leadingTerminal;
 
 /// The terminal which "follows" the lead of the other terminal, only sending
 /// _future_ values to the subscribers of the `leadingTerminal`.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The latest value sent to the `leadingTerminal` (if any) will be sent
 /// immediately to new subscribers of this terminal, and then all future values
 /// as well.
-@property (nonatomic, strong, readonly) RACChannelTerminal *followingTerminal;
+@property (nonatomic, strong, readonly) RACChannelTerminal<ValueType> *followingTerminal;
 
 @end
 
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// terminals.
 ///
 /// Do not instantiate this class directly. Create a RACChannel instead.
-@interface RACChannelTerminal : RACSignal <RACSubscriber>
+@interface RACChannelTerminal<__covariant ValueType> : RACSignal <RACSubscriber>
 
 - (instancetype)init __attribute__((unavailable("Instantiate a RACChannel instead")));
 

--- a/ReactiveObjC/RACChannel.h
+++ b/ReactiveObjC/RACChannel.h
@@ -69,6 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init __attribute__((unavailable("Instantiate a RACChannel instead")));
 
+// Redeclaration of the RACSubscriber method. Made in order to specify a generic type.
+- (void)sendNext:(nullable ValueType)value;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -11,7 +11,7 @@
 #import "RACReplaySubject.h"
 #import "RACSignal+Operations.h"
 
-@interface RACChannelTerminal<__covariant ValueType> ()
+@interface RACChannelTerminal<ValueType> ()
 
 // The values for this terminal.
 @property (nonatomic, strong, readonly) RACSignal<ValueType> *values;

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -11,15 +11,15 @@
 #import "RACReplaySubject.h"
 #import "RACSignal+Operations.h"
 
-@interface RACChannelTerminal ()
+@interface RACChannelTerminal<__covariant ValueType> ()
 
 // The values for this terminal.
-@property (nonatomic, strong, readonly) RACSignal *values;
+@property (nonatomic, strong, readonly) RACSignal<ValueType> *values;
 
 // A subscriber will will send values to the other terminal.
 @property (nonatomic, strong, readonly) id<RACSubscriber> otherTerminal;
 
-- (instancetype)initWithValues:(RACSignal *)values otherTerminal:(id<RACSubscriber>)otherTerminal;
+- (instancetype)initWithValues:(RACSignal<ValueType> *)values otherTerminal:(id<RACSubscriber>)otherTerminal;
 
 @end
 

--- a/ReactiveObjC/RACChannel.m
+++ b/ReactiveObjC/RACChannel.m
@@ -13,10 +13,10 @@
 
 @interface RACChannelTerminal<ValueType> ()
 
-// The values for this terminal.
+/// The values for this terminal.
 @property (nonatomic, strong, readonly) RACSignal<ValueType> *values;
 
-// A subscriber will will send values to the other terminal.
+/// A subscriber will will send values to the other terminal.
 @property (nonatomic, strong, readonly) id<RACSubscriber> otherTerminal;
 
 - (instancetype)initWithValues:(RACSignal<ValueType> *)values otherTerminal:(id<RACSubscriber>)otherTerminal;

--- a/ReactiveObjC/RACKVOChannel.h
+++ b/ReactiveObjC/RACKVOChannel.h
@@ -63,7 +63,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A RACChannel that observes a KVO-compliant key path for changes.
-@interface RACKVOChannel : RACChannel
+@interface RACKVOChannel<__covariant ValueType> : RACChannel<ValueType>
 
 /// Initializes a channel that will observe the given object and key path.
 ///
@@ -85,10 +85,10 @@ NS_ASSUME_NONNULL_BEGIN
 ///            exception if `nil` is received (which might occur if an intermediate
 ///            object is set to `nil`).
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
-- (instancetype)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
+- (instancetype)initWithTarget:(__weak NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable ValueType)nilValue;
 #else
 // Swift builds with OS_OBJECT_HAVE_OBJC_SUPPORT=0 for Playgrounds and LLDB :(
-- (instancetype)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable id)nilValue;
+- (instancetype)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(nullable ValueType)nilValue;
 #endif
 
 - (instancetype)init __attribute__((unavailable("Use -initWithTarget:keyPath:nilValue: instead")));

--- a/ReactiveObjC/RACKVOChannel.h
+++ b/ReactiveObjC/RACKVOChannel.h
@@ -63,7 +63,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// A RACChannel that observes a KVO-compliant key path for changes.
-@interface RACKVOChannel<__covariant ValueType> : RACChannel<ValueType>
+@interface RACKVOChannel<ValueType> : RACChannel<ValueType>
 
 /// Initializes a channel that will observe the given object and key path.
 ///

--- a/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
+++ b/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
@@ -10,6 +10,8 @@
 
 @class RACChannelTerminal;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface UIControl (RACSignalSupportPrivate)
 
 // Adds a RACChannel-based interface to the receiver for the given
@@ -27,3 +29,5 @@
 - (RACChannelTerminal *)rac_channelForControlEvents:(UIControlEvents)controlEvents key:(NSString *)key nilValue:(id)nilValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
+++ b/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 //                 event fires and when a value is sent to the
 //                 RACChannelTerminal respectively.
 // nilValue      - The value to be assigned to the key when `nil` is sent to the
-//                 RACChannelTerminal.
+//                 RACChannelTerminal. This value can itself be nil.
 //
 // Returns a RACChannelTerminal which will send future values from the receiver,
 // and update the receiver when values are sent to the terminal.
-- (RACChannelTerminal *)rac_channelForControlEvents:(UIControlEvents)controlEvents key:(NSString *)key nilValue:(id)nilValue;
+- (RACChannelTerminal *)rac_channelForControlEvents:(UIControlEvents)controlEvents key:(NSString *)key nilValue:(nullable id)nilValue;
 
 @end
 

--- a/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
+++ b/ReactiveObjC/UIControl+RACSignalSupportPrivate.h
@@ -14,18 +14,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIControl (RACSignalSupportPrivate)
 
-// Adds a RACChannel-based interface to the receiver for the given
-// UIControlEvents and exposes it.
-//
-// controlEvents - A mask of UIControlEvents on which to send new values.
-// key           - The key whose value should be read and set when a control
-//                 event fires and when a value is sent to the
-//                 RACChannelTerminal respectively.
-// nilValue      - The value to be assigned to the key when `nil` is sent to the
-//                 RACChannelTerminal. This value can itself be nil.
-//
-// Returns a RACChannelTerminal which will send future values from the receiver,
-// and update the receiver when values are sent to the terminal.
+/// Adds a RACChannel-based interface to the receiver for the given
+/// UIControlEvents and exposes it.
+///
+/// controlEvents - A mask of UIControlEvents on which to send new values.
+/// key           - The key whose value should be read and set when a control
+///                 event fires and when a value is sent to the
+///                 RACChannelTerminal respectively.
+/// nilValue      - The value to be assigned to the key when `nil` is sent to the
+///                 RACChannelTerminal. This value can itself be nil.
+///
+/// Returns a RACChannelTerminal which will send future values from the receiver,
+/// and update the receiver when values are sent to the terminal.
 - (RACChannelTerminal *)rac_channelForControlEvents:(UIControlEvents)controlEvents key:(NSString *)key nilValue:(nullable id)nilValue;
 
 @end

--- a/ReactiveObjC/UIDatePicker+RACSignalSupport.h
+++ b/ReactiveObjC/UIDatePicker+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends the receiver's date whenever the
 /// UIControlEventValueChanged control event is fired, and sets the date to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newDateChannelWithNilValue:(nullable NSDate *)nilValue;
+- (RACChannelTerminal<NSDate *> *)rac_newDateChannelWithNilValue:(nullable NSDate *)nilValue;
 
 @end
 

--- a/ReactiveObjC/UIDatePicker+RACSignalSupport.h
+++ b/ReactiveObjC/UIDatePicker+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
+++ b/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends the receiver's currently selected
 /// segment's index whenever the UIControlEventValueChanged control event is
 /// fired, and sets the selected segment index to the values it receives.
-- (RACChannelTerminal *)rac_newSelectedSegmentIndexChannelWithNilValue:(nullable NSNumber *)nilValue;
+- (RACChannelTerminal<NSNumber *> *)rac_newSelectedSegmentIndexChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
 

--- a/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
+++ b/ReactiveObjC/UISegmentedControl+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactiveObjC/UISlider+RACSignalSupport.h
+++ b/ReactiveObjC/UISlider+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends the receiver's value whenever the
 /// UIControlEventValueChanged control event is fired, and sets the value to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
+- (RACChannelTerminal<NSNumber *> *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
 

--- a/ReactiveObjC/UISlider+RACSignalSupport.h
+++ b/ReactiveObjC/UISlider+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactiveObjC/UIStepper+RACSignalSupport.h
+++ b/ReactiveObjC/UIStepper+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends the receiver's value whenever the
 /// UIControlEventValueChanged control event is fired, and sets the value to the
 /// values it receives.
-- (RACChannelTerminal *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
+- (RACChannelTerminal<NSNumber *> *)rac_newValueChannelWithNilValue:(nullable NSNumber *)nilValue;
 
 @end
 

--- a/ReactiveObjC/UIStepper+RACSignalSupport.h
+++ b/ReactiveObjC/UIStepper+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactiveObjC/UISwitch+RACSignalSupport.h
+++ b/ReactiveObjC/UISwitch+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends whether the receiver is on whenever
 /// the UIControlEventValueChanged control event is fired, and sets it on or off
 /// when it receives @YES or @NO respectively.
-- (RACChannelTerminal *)rac_newOnChannel;
+- (RACChannelTerminal<NSNumber *> *)rac_newOnChannel;
 
 @end
 

--- a/ReactiveObjC/UISwitch+RACSignalSupport.h
+++ b/ReactiveObjC/UISwitch+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ReactiveObjC/UITextField+RACSignalSupport.h
+++ b/ReactiveObjC/UITextField+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal;
+@class RACChannelTerminal<__covariant ValueType>;
 @class RACSignal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns a RACChannelTerminal that sends the receiver's text whenever the
 /// UIControlEventAllEditingEvents control event is fired, and sets the text
 /// to the values it receives.
-- (RACChannelTerminal *)rac_newTextChannel;
+- (RACChannelTerminal<NSString *> *)rac_newTextChannel;
 
 @end
 

--- a/ReactiveObjC/UITextField+RACSignalSupport.h
+++ b/ReactiveObjC/UITextField+RACSignalSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACChannelTerminal<__covariant ValueType>;
+@class RACChannelTerminal<ValueType>;
 @class RACSignal<__covariant ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Both of them now have exactly one associated value (a covariant).