### PR TITLE
Increase version to 3.0.0

### DIFF
--- a/ReactiveObjC.podspec
+++ b/ReactiveObjC.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ReactiveObjC"
-  s.version      = "2.1.2"
+  s.version      = "3.0.0"
   s.summary      = "The 2.x ReactiveCocoa Objective-C API: Streams of values over time"
 
   s.description  = <<-DESC.strip_heredoc

--- a/ReactiveObjC/Info.plist
+++ b/ReactiveObjC/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ReactiveObjCTests/Info.plist
+++ b/ReactiveObjCTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.2</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Includes #75, #80, #81, #82, #83, #85, #87, and #88.

While this has no breaking changes in Obj-C, it will likely introduce breaking changes in Swift. See #90.