### PR TITLE
RACSignal+Operations: modify -sample: for more consistent behavior.

### DIFF
--- a/ReactiveObjC/RACSignal+Operations.h
+++ b/ReactiveObjC/RACSignal+Operations.h
@@ -643,7 +643,8 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
 /// the receiver. Values from `sampler` are ignored before the receiver sends
-/// its first value.
+/// its first value. The signal completes once both the receiver and `sampler`
+/// complete or errs if either the recevier or `sampler` err.
 ///
 /// sampler - The signal that controls when the latest value from the receiver
 ///           is sent. Cannot be nil.


### PR DESCRIPTION
The `-sample:` operator completes once the receiver completes. This
behavior is not suited for this particular operator, which should more
likely complete once the both sampler and the sampled signals complete,
truly indicating it will not send any more values. Both signals still
pass errors through.

Moreover, the convention in RAC is that an operator that operates on
more than one signal completes when the all its inputs complete, and the
current behavior of `-sample:` breaks this convention.