### PR TITLE
Update keypath coding macros

### DIFF
--- a/ReactiveObjC/extobjc/EXTKeyPathCoding.h
+++ b/ReactiveObjC/extobjc/EXTKeyPathCoding.h
@@ -16,14 +16,14 @@
  *
  * @code
 
-NSString *UTF8StringPath = @keypath(str.lowercaseString.UTF8String);
-// => @"lowercaseString.UTF8String"
+ NSString *UTF8StringPath = @keypath(str.lowercaseString.UTF8String);
+ // => @"lowercaseString.UTF8String"
 
-NSString *versionPath = @keypath(NSObject, version);
-// => @"version"
+ NSString *versionPath = @keypath(NSObject, version);
+ // => @"version"
 
-NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
-// => @"lowercaseString"
+ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
+ // => @"lowercaseString"
 
  * @endcode
  *
@@ -36,33 +36,41 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
  * uses of \@keypath.
  */
 #define keypath(...) \
-    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Warc-repeated-use-of-weak\"") \
+(NO).boolValue ? ((NSString * _Nonnull)nil) : ((NSString * _Nonnull)@(cStringKeypath(__VA_ARGS__))) \
+_Pragma("clang diagnostic pop") \
+
+#define cStringKeypath(...) \
+metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(keypath1(__VA_ARGS__))(keypath2(__VA_ARGS__))
 
 #define keypath1(PATH) \
-    (((void)(NO && ((void)PATH, NO)), strchr(# PATH, '.') + 1))
+(((void)(NO && ((void)PATH, NO)), \
+({ char *__extobjckeypath__ = strchr(# PATH, '.'); NSCAssert(__extobjckeypath__, @"Provided key path is invalid."); __extobjckeypath__ + 1; })))
 
 #define keypath2(OBJ, PATH) \
-    (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
+(((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
 
 /**
  * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object
  * receiver, collection object receiver and related keypaths:
  *
  * @code
- 
- NSString *employessFirstNamePath = @collectionKeypath(department.employees, Employee.new, firstName)
+
+ NSString *employeesFirstNamePath = @collectionKeypath(department.employees, Employee.new, firstName)
  // => @"employees.firstName"
- 
- NSString *employessFirstNamePath = @collectionKeypath(Department.new, employees, Employee.new, firstName)
+
+ NSString *employeesFirstNamePath = @collectionKeypath(Department.new, employees, Employee.new, firstName)
  // => @"employees.firstName"
 
  * @endcode
  *
  */
 #define collectionKeypath(...) \
-    metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
+metamacro_if_eq(3, metamacro_argcount(__VA_ARGS__))(collectionKeypath3(__VA_ARGS__))(collectionKeypath4(__VA_ARGS__))
 
-#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
+#define collectionKeypath3(PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+(YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil
 
-#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) ([[NSString stringWithFormat:@"%s.%s",keypath(OBJ, PATH), keypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String])
-
+#define collectionKeypath4(OBJ, PATH, COLLECTION_OBJECT, COLLECTION_PATH) \
+(YES).boolValue ? (NSString * _Nonnull)@((const char * _Nonnull)[[NSString stringWithFormat:@"%s.%s", cStringKeypath(OBJ, PATH), cStringKeypath(COLLECTION_OBJECT, COLLECTION_PATH)] UTF8String]) : (NSString * _Nonnull)nil


### PR DESCRIPTION
Updating keypath coding macros due to compile errors arising from implicit conversion from nullable pointer in `@keypath`