### PR TITLE
Update Podspec for 3.1.1

### DIFF
--- a/ReactiveObjC.podspec
+++ b/ReactiveObjC.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ReactiveObjC"
-  s.version      = "3.1.0"
+  s.version      = "3.1.1"
   s.summary      = "The 2.x ReactiveCocoa Objective-C API: Streams of values over time"
 
   s.description  = <<-DESC.strip_heredoc


### PR DESCRIPTION
Updates the Podspec for yesterdays 3.1.1 Release.
Someone will have to do the actual Cocoapod release as well.