### PR TITLE
chore: explicitly cast LONG_MAX to double

### DIFF
--- a/ReactiveObjC/RACQueueScheduler.m
+++ b/ReactiveObjC/RACQueueScheduler.m
@@ -48,8 +48,8 @@
 	double frac = modf(date.timeIntervalSince1970, &seconds);
 
 	struct timespec walltime = {
-		.tv_sec = (time_t)fmin(fmax(seconds, LONG_MIN), LONG_MAX),
-		.tv_nsec = (long)fmin(fmax(frac * NSEC_PER_SEC, LONG_MIN), LONG_MAX)
+		.tv_sec = (time_t)fmin(fmax(seconds, LONG_MIN), (double)LONG_MAX),
+		.tv_nsec = (long)fmin(fmax(frac * NSEC_PER_SEC, LONG_MIN), (double)LONG_MAX)
 	};
 
 	return dispatch_walltime(&walltime, 0);


### PR DESCRIPTION
Fixes a compilation error encountered in Electron as a result of Chromium enabling the `-Wimplicit-const-int-float-conversion` compilation flag in [this CL](https://chromium-review.googlesource.com/c/chromium/src/+/3001416).

<details>

<summary>Compilation Failure</summary>

```
../../third_party/squirrel.mac/vendor/ReactiveObjC/ReactiveObjC/RACQueueScheduler.m:52:62: error: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
                .tv_nsec = (long)fmin(fmax(frac * NSEC_PER_SEC, LONG_MIN), LONG_MAX)
                                 ~~~~                                      ^~~~~~~~
../../third_party/llvm-build/Release+Asserts/lib/clang/13.0.0/include/limits.h:47:19: note: expanded from macro 'LONG_MAX'
#define LONG_MAX  __LONG_MAX__
                  ^~~~~~~~~~~~
<built-in>:53:22: note: expanded from here
#define __LONG_MAX__ 9223372036854775807L
                     ^~~~~~~~~~~~~~~~~~~~
../../third_party/squirrel.mac/vendor/ReactiveObjC/ReactiveObjC/RACQueueScheduler.m:51:51: error: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
                .tv_sec = (time_t)fmin(fmax(seconds, LONG_MIN), LONG_MAX),
                                  ~~~~                          ^~~~~~~~
../../third_party/llvm-build/Release+Asserts/lib/clang/13.0.0/include/limits.h:47:19: note: expanded from macro 'LONG_MAX'
#define LONG_MAX  __LONG_MAX__
                  ^~~~~~~~~~~~
<built-in>:53:22: note: expanded from here
#define __LONG_MAX__ 9223372036854775807L
                     ^~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

</details>

Please let me know if I need to make other associated changes or you all would prefer another approach to fixing this issue!