### PR TITLE
Fix invoke original selector when have ReactiveCocoa selector subscribers and ReactiveObjC

### DIFF
--- a/ReactiveObjC/NSObject+RACSelectorSignal.m
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.m
@@ -53,8 +53,10 @@ static BOOL RACForwardInvocation(id self, NSInvocation *invocation) {
 	[subject sendNext:invocation.rac_argumentsTuple];
 
 	NSString *className = NSStringFromClass(class);
+	NSString *selName = NSStringFromSelector(invocation.selector);
 	Class statedClass = [invocation.target class];
-	if (statedClass != class && ![className containsString:RACSubclassSuffix]) {
+	if (statedClass != class && ![className containsString:RACSubclassSuffix]
+		&& ![selName hasPrefix:RACSignalForSelectorAliasPrefix]) {
 		return NO;
 	}
 

--- a/ReactiveObjC/NSObject+RACSelectorSignal.m
+++ b/ReactiveObjC/NSObject+RACSelectorSignal.m
@@ -51,6 +51,13 @@ static BOOL RACForwardInvocation(id self, NSInvocation *invocation) {
 	if (subject == nil) return respondsToAlias;
 
 	[subject sendNext:invocation.rac_argumentsTuple];
+
+	NSString *className = NSStringFromClass(class);
+	Class statedClass = [invocation.target class];
+	if (statedClass != class && ![className containsString:RACSubclassSuffix]) {
+		return NO;
+	}
+
 	return YES;
 }
 


### PR DESCRIPTION
Precondition:
UIViewController.swift:
 reactive.viewDidAppear
            .observeValues { [weak self] _ in
                guard let self else { return }
                print("\(self)")
            }

Other code:
@weakify(self);
    [[vc rac_signalForSelector:@selector(viewWillDisappear:)] subscribeNext:^(id x) {
        @strongify(self);
       NSLog(@"%@", self)
    }];

then 
viewWillDisappear not invoked in UIViewController.swift